### PR TITLE
Move main to a cmd subpkg, change package main to package keysync

### DIFF
--- a/TODO
+++ b/TODO
@@ -13,5 +13,5 @@
  * Integration tests - against a real keywhiz server
  * Factor out common client library
  * Kill dead code imported
- * Refactor & cleanup
+ * Refactor & cleanup, move code into a `package keysync` so it can be reused.
  * Shutdown handling of some sort (catch signal, log, exit)

--- a/api.go
+++ b/api.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package keysync
 
 import (
 	"fmt"

--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package keysync
 
 import (
 	"crypto/tls"

--- a/client.go
+++ b/client.go
@@ -64,6 +64,7 @@ type httpClientParams struct {
 	timeout  time.Duration
 }
 
+// SecretDeleted is returned as an error when the server 404s.
 type SecretDeleted struct{}
 
 func (e SecretDeleted) Error() string {
@@ -96,6 +97,8 @@ func NewClient(certFile, keyFile, caFile string, serverURL *url.URL, timeout tim
 	return Client{logger, initial, serverURL, params, failCount, lastSuccess}, nil
 }
 
+// RebuildClient reloads certificates from disk.  It should be called periodically to ensure up-to-date client
+// certificates are used.  This is important if you're using short-lived certificates that are routinely replaced.
 func (c *Client) RebuildClient() error {
 	client, err := c.params.buildClient()
 	if err != nil {

--- a/cmd/keysync.go
+++ b/cmd/keysync.go
@@ -26,6 +26,8 @@ import (
 	"github.com/rcrowley/go-metrics"
 	"github.com/square/go-sq-metrics"
 	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/square/keysync"
 )
 
 func main() {
@@ -37,7 +39,7 @@ func main() {
 
 	fmt.Printf("Loading config: %s\n", *configFile)
 
-	config, err := LoadConfig(*configFile)
+	config, err := keysync.LoadConfig(*configFile)
 	if err != nil {
 		log.Fatalf("Couldn't load configuration: %v", err)
 	}
@@ -50,14 +52,14 @@ func main() {
 	raven.CapturePanicAndWait(func() {
 		metricsHandle := sqmetrics.NewMetrics(config.MetricsURL, config.MetricsPrefix, http.DefaultClient, 30*time.Second, metrics.DefaultRegistry, &log.Logger{})
 
-		syncer, err := NewSyncer(config, metricsHandle)
+		syncer, err := keysync.NewSyncer(config, metricsHandle)
 		if err != nil {
 			raven.CaptureErrorAndWait(err, nil)
 		}
 
 		// Start the API server
 		if config.APIPort != 0 {
-			NewAPIServer(syncer, config.APIPort)
+			keysync.NewAPIServer(syncer, config.APIPort)
 		}
 
 		err = syncer.Run()

--- a/config.go
+++ b/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package keysync
 
 import (
 	"fmt"

--- a/ownership.go
+++ b/ownership.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package keysync
 
 import (
 	"bufio"

--- a/ownership.go
+++ b/ownership.go
@@ -28,20 +28,20 @@ var groupFile = "/etc/group"
 
 // Ownership indicates the default ownership of filesystem entries.
 type Ownership struct {
-	Uid uint32
-	Gid uint32
+	UID uint32
+	GID uint32
 }
 
 // NewOwnership initializes default file ownership struct.
 func NewOwnership(username, groupname string) Ownership {
 	return Ownership{
-		Uid: lookupUid(username),
-		Gid: lookupGid(groupname),
+		UID: lookupUID(username),
+		GID: lookupGID(groupname),
 	}
 }
 
-// lookupUid resolves a username to a numeric id. Current euid is returned on failure.
-func lookupUid(username string) uint32 {
+// lookupUID resolves a username to a numeric id. Current euid is returned on failure.
+func lookupUID(username string) uint32 {
 	u, err := user.Lookup(username)
 	if err != nil {
 		log.Printf("Error resolving uid for %v: %v\n", username, err)
@@ -57,8 +57,8 @@ func lookupUid(username string) uint32 {
 	return uint32(uid)
 }
 
-// lookupGid resolves a groupname to a numeric id. Current egid is returned on failure.
-func lookupGid(groupname string) uint32 {
+// lookupGID resolves a groupname to a numeric id. Current egid is returned on failure.
+func lookupGID(groupname string) uint32 {
 	file, err := os.Open(groupFile)
 	if err != nil {
 		log.Printf("Error resolving gid for %v: %v\n", groupname, err)

--- a/secret.go
+++ b/secret.go
@@ -78,10 +78,10 @@ func (s Secret) ModeValue() os.FileMode {
 func (s Secret) OwnershipValue(fallback Ownership) (ownership Ownership) {
 	ownership = fallback
 	if s.Owner != "" {
-		ownership.Uid = lookupUid(s.Owner)
+		ownership.UID = lookupUID(s.Owner)
 	}
 	if s.Group != "" {
-		ownership.Gid = lookupGid(s.Group)
+		ownership.GID = lookupGID(s.Group)
 	}
 	return
 }

--- a/secret.go
+++ b/secret.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"os"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -56,7 +58,7 @@ type Secret struct {
 }
 
 // ModeValue function helps by converting a textual mode to the expected value for fuse.
-func (s Secret) ModeValue() uint32 {
+func (s Secret) ModeValue() os.FileMode {
 	mode := s.Mode
 	if mode == "" {
 		mode = "0440"
@@ -68,7 +70,7 @@ func (s Secret) ModeValue() uint32 {
 	}
 	// The only acceptable bits to set in a mode are read bits, so we mask off any additional bits.
 	modeValue = modeValue & 0444
-	return uint32(modeValue | unix.S_IFREG)
+	return os.FileMode(modeValue | unix.S_IFREG)
 }
 
 // OwnershipValue returns the ownership for a given secret, falling back to the values given as

--- a/secret.go
+++ b/secret.go
@@ -46,14 +46,13 @@ func ParseSecretList(data []byte) (secrets []Secret, err error) {
 //
 // json tags after fields indicate to json decoder the key name in JSON
 type Secret struct {
-	Name        string
-	Content     content   `json:"secret"`
-	Length      uint64    `json:"secretLength"`
-	CreatedAt   time.Time `json:"creationDate"`
-	IsVersioned bool
-	Mode        string
-	Owner       string
-	Group       string
+	Name      string
+	Content   content   `json:"secret"`
+	Length    uint64    `json:"secretLength"`
+	CreatedAt time.Time `json:"creationDate"`
+	Mode      string
+	Owner     string
+	Group     string
 }
 
 // ModeValue function helps by converting a textual mode to the expected value for fuse.

--- a/secret.go
+++ b/secret.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package keysync
 
 import (
 	"encoding/base64"

--- a/syncer.go
+++ b/syncer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package keysync
 
 import "fmt"
 import (

--- a/syncer_test.go
+++ b/syncer_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package keysync
 
 import (
 	"testing"

--- a/syncer_test.go
+++ b/syncer_test.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/write.go
+++ b/write.go
@@ -53,7 +53,7 @@ func atomicWrite(name string, secret *Secret, writeConfig WriteConfig) error {
 	if writeConfig.ChownFiles {
 		ownership := secret.OwnershipValue(writeConfig.DefaultOwnership)
 
-		err = f.Chown(int(ownership.Uid), int(ownership.Gid))
+		err = f.Chown(int(ownership.UID), int(ownership.GID))
 		if err != nil {
 			fmt.Printf("Chown failed: %v\n", err)
 			return err

--- a/write.go
+++ b/write.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package keysync
 
 import (
 	"crypto/rand"

--- a/write.go
+++ b/write.go
@@ -61,7 +61,7 @@ func atomicWrite(name string, secret *Secret, writeConfig WriteConfig) error {
 	}
 
 	// Always Chmod after the Chown, so we don't expose secret with the wrong owner.
-	err = f.Chmod(os.FileMode(secret.ModeValue()))
+	err = f.Chmod(secret.ModeValue())
 	if err != nil {
 		return err
 


### PR DESCRIPTION
This allows easier use of the Keysync code as a library, which might be
important if you want to integrate code not suitable for the open source
library, such as a custom logrus hook, or simply too opinionated for a shared
open source project.

We debated in person a bit about whether to do it this way, or move non-main
code into a `lib` folder.  I think this way makes it easier to work with the
codebase, since it's `package keysync` instead of lib.  Having a `cmd` folder
also allows us to add more commands in the future easily.

Also clean up some `go lint` nits.