### PR TITLE
Configure a base secrets directory, and subdirectories for each client

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -67,24 +67,24 @@ func TestConfigLoadClientsSuccess(t *testing.T) {
 	clients, err := config.LoadClients()
 	newAssert.Nil(err)
 
-	for _, name := range []string{"client1", "client2", "client3", "client4"} {
+	for _, name := range []string{"client1", "client2", "client3"} {
 		client, ok := clients[name]
 		newAssert.True(ok)
-		newAssert.Equal(fmt.Sprintf("fixtures/clients/%s", name), client.Mountpoint)
+		newAssert.Equal(name, client.DirName)
 		newAssert.Equal(fmt.Sprintf("fixtures/clients/%s.key", name), client.Key)
 		newAssert.Equal(fmt.Sprintf("fixtures/clients/%s.crt", name), client.Cert)
 	}
 
+	assert.Equal(t, "client4_overridden", clients["client4"].DirName)
+
 	client, ok := clients["missingcert"]
 	newAssert.True(ok)
-	newAssert.Equal("fixtures/clients/missingcert", client.Mountpoint)
 	newAssert.Equal("fixtures/clients/client4.key", client.Key)
 	// With no cert specified, it's assumed to be in the key file
 	newAssert.Equal("fixtures/clients/client4.key", client.Cert)
 
 	client, ok = clients["owners"]
 	newAssert.True(ok)
-	newAssert.Equal("fixtures/clients/owners", client.Mountpoint)
 	newAssert.Equal("fixtures/clients/client1.key", client.Key)
 	newAssert.Equal("fixtures/clients/client1.crt", client.Cert)
 	newAssert.Equal("test-user", client.User)
@@ -98,13 +98,10 @@ func TestConfigLoadClientsInvalidFiles(t *testing.T) {
 	_, err = config.LoadClients()
 	assert.NotNil(t, err)
 
-	config, err = LoadConfig("fixtures/configs/errorconfigs/missingkey-config.yaml")
-	require.Nil(t, err)
-
-	_, err = config.LoadClients()
+	_, err = LoadConfig("fixtures/configs/errorconfigs/missing-secrets-dir-config.yaml")
 	assert.NotNil(t, err)
 
-	config, err = LoadConfig("fixtures/configs/errorconfigs/missingmount-config.yaml")
+	config, err = LoadConfig("fixtures/configs/errorconfigs/missingkey-config.yaml")
 	require.Nil(t, err)
 
 	_, err = config.LoadClients()

--- a/fixtures/clients/abscert.yaml
+++ b/fixtures/clients/abscert.yaml
@@ -2,4 +2,3 @@
 client1:
     key: client1.key
     cert: /nonexistent/non-dir/missing-dir/test-absolute-path/client1.crt
-    mountpoint: client1

--- a/fixtures/clients/client1.yaml
+++ b/fixtures/clients/client1.yaml
@@ -2,4 +2,3 @@
 client1:
     key: client1.key
     cert: client1.crt
-    mountpoint: client1

--- a/fixtures/clients/client2-3.yaml
+++ b/fixtures/clients/client2-3.yaml
@@ -2,9 +2,7 @@
 client2:
     key: client2.key
     cert: client2.crt
-    mountpoint: client2
 
 client3:
     key: client3.key
     cert: client3.crt
-    mountpoint: client3

--- a/fixtures/clients/client4.yaml
+++ b/fixtures/clients/client4.yaml
@@ -2,4 +2,4 @@
 client4:
     key: client4.key
     cert: client4.crt
-    mountpoint: client4
+    directory: client4_overridden

--- a/fixtures/clients/missingcert.yaml
+++ b/fixtures/clients/missingcert.yaml
@@ -1,4 +1,3 @@
 ---
 missingcert:
     key: client4.key
-    mountpoint: missingcert

--- a/fixtures/clients/owners.yaml
+++ b/fixtures/clients/owners.yaml
@@ -2,6 +2,5 @@
 owners:
     key: client1.key
     cert: client1.crt
-    mountpoint: owners
     user: test-user
     group: test-group

--- a/fixtures/configs/errorconfigs/absolutecert-config.yaml
+++ b/fixtures/configs/errorconfigs/absolutecert-config.yaml
@@ -1,5 +1,6 @@
 ---
 client_directory: 'fixtures/clients/abscert.yaml'
+secrets_directory: 'fixtures/secrets'
 ca_file: 'fixtures/CA/cacert.crt'
 yaml_ext: yaml
 chown_files: false

--- a/fixtures/configs/errorconfigs/missing-secrets-dir-config.yaml
+++ b/fixtures/configs/errorconfigs/missing-secrets-dir-config.yaml
@@ -1,5 +1,5 @@
 ---
-client_directory: 'fixtures/errorclients/missingmount'
+client_directory: 'fixtures/clients'
 ca_file: 'fixtures/CA/cacert.crt'
 yaml_ext: yaml
 chown_files: false

--- a/fixtures/configs/errorconfigs/missingkey-config.yaml
+++ b/fixtures/configs/errorconfigs/missingkey-config.yaml
@@ -1,5 +1,6 @@
 ---
 client_directory: 'fixtures/errorclients/missingkey'
+secrets_directory: 'fixtures/secrets'
 ca_file: 'fixtures/CA/cacert.crt'
 yaml_ext: yaml
 chown_files: false

--- a/fixtures/configs/errorconfigs/nonexistent-ca-file-config.yaml
+++ b/fixtures/configs/errorconfigs/nonexistent-ca-file-config.yaml
@@ -1,5 +1,6 @@
 ---
 client_directory: 'fixtures/clients'
+secrets_directory: 'fixtures/secrets'
 ca_file: 'non-existent'
 yaml_ext: yaml
 chown_files: false

--- a/fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml
+++ b/fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml
@@ -1,5 +1,6 @@
 ---
 client_directory: 'non-existent'
+secrets_directory: 'fixtures/secrets'
 ca_file: 'fixtures/CA/cacert.crt'
 yaml_ext: yaml
 chown_files: false

--- a/fixtures/configs/errorconfigs/notyaml-client-config.yaml
+++ b/fixtures/configs/errorconfigs/notyaml-client-config.yaml
@@ -1,5 +1,6 @@
 ---
 client_directory: 'fixtures/errorclients/notyaml'
+secrets_directory: 'fixtures/secrets'
 ca_file: 'fixtures/CA/cacert.crt'
 yaml_ext: yaml
 chown_files: false

--- a/fixtures/configs/test-config.yaml
+++ b/fixtures/configs/test-config.yaml
@@ -1,5 +1,6 @@
 ---
 client_directory: 'fixtures/clients'
+secrets_directory: 'fixtures/secrets'
 ca_file: 'fixtures/CA/cacert.crt'
 yaml_ext: yaml
 chown_files: false

--- a/fixtures/errorclients/missingmount/missingmount.yaml
+++ b/fixtures/errorclients/missingmount/missingmount.yaml
@@ -1,4 +1,0 @@
----
-missingmount:
-    key: client4.key
-    cert: client4.crt


### PR DESCRIPTION
This makes keysync easier to configure, because it's one less thing per-client
In practise for us, the key for each client entry in the yaml is what we want
that directory to be called, so this means we can simplify our configs.  It
also gives us an easier migration path because two syncers can share a client
config folder (which is host-specific), and sync to different locations based
on a different global configuration.