### PR TITLE
Add basic monitoring binary

### DIFF
--- a/api.go
+++ b/api.go
@@ -42,20 +42,21 @@ type APIServer struct {
 	logger *logrus.Entry
 }
 
-type statusResponse struct {
+// StatusResponse from API endpoints
+type StatusResponse struct {
 	Ok      bool   `json:"ok"`
 	Message string `json:"message"`
 }
 
 func writeSuccess(w http.ResponseWriter) {
-	resp := &statusResponse{Ok: true}
+	resp := &StatusResponse{Ok: true}
 	out, _ := json.Marshal(resp)
 	w.WriteHeader(http.StatusOK)
 	w.Write(out)
 }
 
 func writeError(w http.ResponseWriter, status int, err error) {
-	resp := &statusResponse{Ok: false, Message: err.Error()}
+	resp := &StatusResponse{Ok: false, Message: err.Error()}
 	out, _ := json.Marshal(resp)
 	w.WriteHeader(status)
 	w.Write(out)

--- a/api_test.go
+++ b/api_test.go
@@ -68,7 +68,7 @@ func TestApiSyncAllAndSyncClientSuccess(t *testing.T) {
 	data, _ := ioutil.ReadAll(res.Body)
 	require.Nil(t, err)
 
-	status := statusResponse{}
+	status := StatusResponse{}
 	err = json.Unmarshal(data, &status)
 	require.Nil(t, err)
 	require.True(t, status.Ok)
@@ -84,7 +84,7 @@ func TestApiSyncAllAndSyncClientSuccess(t *testing.T) {
 	data, _ = ioutil.ReadAll(res.Body)
 	require.Nil(t, err)
 
-	status = statusResponse{}
+	status = StatusResponse{}
 	err = json.Unmarshal(data, &status)
 	require.Nil(t, err)
 	require.True(t, status.Ok)
@@ -100,7 +100,7 @@ func TestApiSyncAllAndSyncClientSuccess(t *testing.T) {
 	data, _ = ioutil.ReadAll(res.Body)
 	require.Nil(t, err)
 
-	status = statusResponse{}
+	status = StatusResponse{}
 	err = json.Unmarshal(data, &status)
 	require.Nil(t, err)
 	require.False(t, status.Ok)

--- a/monitor/checks.go
+++ b/monitor/checks.go
@@ -1,0 +1,75 @@
+// Copyright 2017 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/square/keysync"
+)
+
+func checkPaths(config *keysync.Config) []error {
+	errs := []error{}
+	errs = append(errs, directoryExists(config.SecretsDir)...)
+	errs = append(errs, directoryExists(config.ClientsDir)...)
+	errs = append(errs, fileExists(config.CaFile)...)
+	return errs
+}
+
+func checkServerHealth(config *keysync.Config) []error {
+	url := fmt.Sprintf("http://localhost:%d/status", config.APIPort)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return []error{fmt.Errorf("unable to talk to status: %s", err)}
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return []error{fmt.Errorf("unable to talk to status: %s", err)}
+	}
+
+	status := &keysync.StatusResponse{}
+	err = json.Unmarshal(body, &status)
+	if err != nil {
+		return []error{fmt.Errorf("invalid JSON status response: %s", err)}
+	}
+
+	if !status.Ok {
+		return []error{fmt.Errorf("keysync unhealthy: %s", status.Message)}
+	}
+
+	return nil
+}
+
+func fileExists(path string) []error {
+	fi, err := os.Stat(path)
+	if err != nil || fi.IsDir() {
+		return []error{fmt.Errorf("expected '%s' to be a file", path)}
+	}
+	return nil
+}
+
+func directoryExists(path string) []error {
+	fi, err := os.Stat(path)
+	if err != nil || !fi.IsDir() {
+		return []error{fmt.Errorf("expected '%s' to be a directory", path)}
+	}
+	return nil
+}

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -1,0 +1,67 @@
+// Copyright 2017 Square Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/square/keysync"
+)
+
+func main() {
+	var (
+		app        = kingpin.New("keysync-monitor", "Health check/monitor for keysync")
+		configFile = app.Flag("config", "The base YAML configuration file").PlaceHolder("config.yaml").Required().String()
+	)
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	config, err := keysync.LoadConfig(*configFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed loading configuration: %s\n", err)
+		os.Exit(1)
+	}
+
+	checks := []func(*keysync.Config) []error{
+		checkPaths,
+		checkServerHealth,
+	}
+
+	errs := runChecks(config, checks)
+	if len(errs) > 0 {
+		printErrors(errs)
+		os.Exit(1)
+	}
+}
+
+func runChecks(config *keysync.Config, checks []func(*keysync.Config) []error) []error {
+	errs := []error{}
+	for _, check := range checks {
+		e := check(config)
+		if len(e) > 0 {
+			errs = append(errs, e...)
+		}
+	}
+	return errs
+}
+
+func printErrors(errs []error) {
+	fmt.Fprintf(os.Stderr, "found the following problems:\n")
+	for _, err := range errs {
+		fmt.Fprintf(os.Stderr, "- %s\n", err)
+	}
+}

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -39,6 +39,7 @@ func main() {
 	checks := []func(*keysync.Config) []error{
 		checkPaths,
 		checkServerHealth,
+		checkDiskUsage,
 	}
 
 	errs := runChecks(config, checks)
@@ -54,6 +55,7 @@ func runChecks(config *keysync.Config, checks []func(*keysync.Config) []error) [
 		e := check(config)
 		if len(e) > 0 {
 			errs = append(errs, e...)
+			return errs
 		}
 	}
 	return errs


### PR DESCRIPTION
Adds a basic monitoring/health checking binary that can run on any machine where keysync runs (with the same config), and perform basic checks to make sure everything is ok (can be expanded in future). Returns 0 or 1 depending on whether any problems were found.