### PR TITLE
Skip darwin in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ go:
  - 1.7.5
  - 1.8
  - tip
-env:
- - BUILD_GOOS=darwin
- - BUILD_GOOS=linux
 
 script:
- - GOOS=$BUILD_GOOS go build -o keysync cmd/keysync.go
+ - go build -o keysync cmd/keysync.go
  - go test -v .


### PR DESCRIPTION
We're crosscompiling to darwin today but not testing.  And yet it's still flakey.  Let's skip it, since it's not a production OS we need to ship for right now