### PR TITLE
Revert "Skip darwin in travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ go:
  - 1.7.5
  - 1.8
  - tip
+env:
+ - BUILD_GOOS=darwin
+ - BUILD_GOOS=linux
 
 script:
- - go build -o keysync cmd/keysync.go
+ - GOOS=$BUILD_GOOS go build -o keysync cmd/keysync.go
  - go test -v .


### PR DESCRIPTION
Reverts square/keysync#32

Still seeing test failures -- I think it was just co-incidence it was happening on the `darwin` builds.  Some race condition in how we're setting up the mock server I guess.

--- FAIL: TestApiSyncAllAndSyncClientSuccess (0.00s)
	Error Trace:	api_test.go:66
	Error:      	Expected nil, but got: &url.Error{Op:"Post", URL:"http://localhost:46391/sync", Err:(*net.OpError)

