### PR TITLE
Ownership fixes

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -41,12 +41,6 @@ func randomPort() uint16 {
 }
 
 func TestApiSyncAllAndSyncClientSuccess(t *testing.T) {
-	groupFile = "fixtures/ownership/group"
-	defer func() { groupFile = "/etc/group" }()
-
-	passwdFile = "fixtures/ownership/passwd"
-	defer func() { passwdFile = "/etc/passwd" }()
-
 	port := randomPort()
 
 	server := createDefaultServer()
@@ -107,12 +101,6 @@ func TestApiSyncAllAndSyncClientSuccess(t *testing.T) {
 }
 
 func TestApiSyncOneError(t *testing.T) {
-	groupFile = "fixtures/ownership/group"
-	defer func() { groupFile = "/etc/group" }()
-
-	passwdFile = "fixtures/ownership/passwd"
-	defer func() { passwdFile = "/etc/passwd" }()
-
 	port := randomPort()
 
 	config, err := LoadConfig("fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml")
@@ -144,12 +132,6 @@ func TestApiSyncOneError(t *testing.T) {
 }
 
 func TestHealthCheck(t *testing.T) {
-	groupFile = "fixtures/ownership/group"
-	defer func() { groupFile = "/etc/group" }()
-
-	passwdFile = "fixtures/ownership/passwd"
-	defer func() { passwdFile = "/etc/passwd" }()
-
 	port := randomPort()
 
 	config, err := LoadConfig("fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml")
@@ -183,12 +165,6 @@ func TestHealthCheck(t *testing.T) {
 }
 
 func TestMetricsReporting(t *testing.T) {
-	groupFile = "fixtures/ownership/group"
-	defer func() { groupFile = "/etc/group" }()
-
-	passwdFile = "fixtures/ownership/passwd"
-	defer func() { passwdFile = "/etc/passwd" }()
-
 	port := randomPort()
 
 	config, err := LoadConfig("fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml")

--- a/config.go
+++ b/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	Debug         bool       `yaml:"debug"`             // Enable debugging output
 	DefaultUser   string     `yaml:"default_user"`      // Default user to own files
 	DefaultGroup  string     `yaml:"default_group"`     // Default group to own files
+	PasswdFile    string     `yaml:"passwd_file"`       // /etc/passwd, for uid lookups
+	GroupFile     string     `yaml:"group_file"`        // /etc/groups, for gid lookups
 	APIPort       uint16     `yaml:"api_port"`          // Port for API to listen on
 	SentryDSN     string     `yaml:"sentry_dsn"`        // Sentry DSN
 	FsType        Filesystem `yaml:"filesystem_type"`   // Enforce writing this type of filesystem. Use value from statfs.
@@ -64,6 +66,14 @@ func LoadConfig(configFile string) (*Config, error) {
 
 	if config.SecretsDir == "" {
 		return nil, fmt.Errorf("Mandatory config secrets_directory not provided: %s", configFile)
+	}
+
+	if config.PasswdFile == "" {
+		config.PasswdFile = "/etc/passwd"
+	}
+
+	if config.GroupFile == "" {
+		config.GroupFile = "/etc/group"
 	}
 
 	return &config, nil

--- a/fixtures/configs/errorconfigs/absolutecert-config.yaml
+++ b/fixtures/configs/errorconfigs/absolutecert-config.yaml
@@ -8,5 +8,7 @@ server: 'localhost:4444'
 debug: true
 default_user: 'keysync-test'
 default_group: 'keysync-test'
+passwd_file : 'fixtures/ownership/passwd'
+group_file: 'fixtures/ownership/group'
 api_port: 31738
 poll_interval: 60s

--- a/fixtures/configs/errorconfigs/missing-secrets-dir-config.yaml
+++ b/fixtures/configs/errorconfigs/missing-secrets-dir-config.yaml
@@ -7,5 +7,7 @@ server: 'localhost:4444'
 debug: true
 default_user: 'keysync-test'
 default_group: 'keysync-test'
+passwd_file : 'fixtures/ownership/passwd'
+group_file: 'fixtures/ownership/group'
 api_port: 31738
 poll_interval: 60s

--- a/fixtures/configs/errorconfigs/missingkey-config.yaml
+++ b/fixtures/configs/errorconfigs/missingkey-config.yaml
@@ -8,5 +8,7 @@ server: 'localhost:4444'
 debug: true
 default_user: 'keysync-test'
 default_group: 'keysync-test'
+passwd_file : 'fixtures/ownership/passwd'
+group_file: 'fixtures/ownership/group'
 api_port: 31738
 poll_interval: 60s

--- a/fixtures/configs/errorconfigs/nonexistent-ca-file-config.yaml
+++ b/fixtures/configs/errorconfigs/nonexistent-ca-file-config.yaml
@@ -8,5 +8,7 @@ server: 'localhost:4444'
 debug: true
 default_user: 'keysync-test'
 default_group: 'keysync-test'
+passwd_file : 'fixtures/ownership/passwd'
+group_file: 'fixtures/ownership/group'
 api_port: 31738
 poll_interval: 60s

--- a/fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml
+++ b/fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml
@@ -8,5 +8,7 @@ server: 'localhost:4444'
 debug: true
 default_user: 'keysync-test'
 default_group: 'keysync-test'
+passwd_file : 'fixtures/ownership/passwd'
+group_file: 'fixtures/ownership/group'
 api_port: 31738
 poll_interval: 60s

--- a/fixtures/configs/errorconfigs/notyaml-client-config.yaml
+++ b/fixtures/configs/errorconfigs/notyaml-client-config.yaml
@@ -8,5 +8,7 @@ server: 'localhost:4444'
 debug: true
 default_user: 'keysync-test'
 default_group: 'keysync-test'
+passwd_file : 'fixtures/ownership/passwd'
+group_file: 'fixtures/ownership/group'
 api_port: 31738
 poll_interval: 60s

--- a/fixtures/configs/test-config.yaml
+++ b/fixtures/configs/test-config.yaml
@@ -8,5 +8,7 @@ server: 'localhost:4444'
 debug: true
 default_user: 'keysync-test'
 default_group: 'keysync-test'
+passwd_file : 'fixtures/ownership/passwd'
+group_file: 'fixtures/ownership/group'
 api_port: 31738
 poll_interval: 60s

--- a/fixtures/ownership/group
+++ b/fixtures/ownership/group
@@ -1,5 +1,5 @@
-test0:x:1234:test0,test1
-test1:x:1235:test0,test1
-test2:x:1236:test0,test1
-test3:x:baddata:test0,test1
-keysync-test:x:1237:keysync-test
+group0:x:2000:test0,test1
+group1:x:2001:test0,test1
+group2:x:2002:test0,test1
+badgroup:x:baddata:test0,test1
+keysync-test:x:2005:keysync-test

--- a/fixtures/ownership/passwd
+++ b/fixtures/ownership/passwd
@@ -1,5 +1,5 @@
-test0:x:1234:1234:test0:/test0:/bin/bash
-test1:x:1235:1235:test1:/etc/test1:/sbin/nologin
-test2:x:1236:1236:test2:/var/lib/test0:/bin/bash
-test3:x:baddata:1236:test2:/var/lib/test0:/bin/bash
-keysync-test:x:1237:keysync-test:/var/lib/test0:/bin/bash  
+test0:x:1000:2000:test0:/test0:/bin/bash
+test1:x:1001:2001:test1:/etc/test1:/sbin/nologin
+test2:x:1002:2002:test2:/var/lib/test0:/bin/bash
+baddata:x:baddata:2003:test2:/var/lib/test0:/bin/bash
+keysync-test:x:2005:keysync-test:/var/lib/test0:/bin/bash

--- a/ownership.go
+++ b/ownership.go
@@ -46,7 +46,7 @@ func NewOwnership(username, groupname, fallbackUser, fallbackGroup, passwdFile, 
 		uid, err = lookupUID(fallbackUser, passwdFile)
 		if err != nil {
 			uid = 0
-			logger.WithError(err).WithField("user", username).Error("Error looking up fallback username, using 0")
+			logger.WithError(err).WithField("user", fallbackUser).Error("Error looking up fallback username, using 0")
 		}
 	}
 
@@ -56,7 +56,7 @@ func NewOwnership(username, groupname, fallbackUser, fallbackGroup, passwdFile, 
 		gid, err = lookupGID(fallbackGroup, groupFile)
 		if err != nil {
 			gid = 0
-			logger.WithError(err).WithField("group", groupname).Error("Error looking up fallback groupname, using 0")
+			logger.WithError(err).WithField("group", fallbackGroup).Error("Error looking up fallback groupname, using 0")
 		}
 	}
 
@@ -106,5 +106,5 @@ func lookupIDInFile(name, fileName string) (uint32, error) {
 		}
 	}
 
-	return 0, fmt.Errorf("%s not found", name)
+	return 0, fmt.Errorf("%s not found in %s", name, fileName)
 }

--- a/ownership.go
+++ b/ownership.go
@@ -20,35 +20,56 @@ import (
 	"os"
 	"strconv"
 	"strings"
-)
 
-var passwdFile = "/etc/passwd"
-var groupFile = "/etc/group"
+	"github.com/Sirupsen/logrus"
+)
 
 // Ownership indicates the default ownership of filesystem entries.
 type Ownership struct {
 	UID uint32
 	GID uint32
+	// Where to look up users and groups
+	userSource  string
+	groupSource string
 }
 
 // NewOwnership initializes default file ownership struct.
-func NewOwnership(username, groupname string) (Ownership, error) {
-	uid, err := lookupUID(username)
+// Logs as error anything that goes wrong, but always returns something
+// Worst-case you get "0", ie root, owning things, which is safe as root can always read all files.
+func NewOwnership(username, groupname, fallbackUser, fallbackGroup, passwdFile, groupFile string, logger *logrus.Entry) Ownership {
+	var uid, gid uint32
+	var err error
+
+	uid, err = lookupUID(username, passwdFile)
 	if err != nil {
-		return Ownership{}, err
+		logger.WithError(err).WithField("user", username).Error("Error looking up username, using fallback")
+		uid, err = lookupUID(fallbackUser, passwdFile)
+		if err != nil {
+			uid = 0
+			logger.WithError(err).WithField("user", username).Error("Error looking up fallback username, using 0")
+		}
 	}
-	gid, err := lookupGID(groupname)
+
+	gid, err = lookupGID(groupname, groupFile)
 	if err != nil {
-		return Ownership{}, err
+		logger.WithError(err).WithField("group", groupname).Error("Error looking up groupname, using fallback")
+		gid, err = lookupGID(fallbackGroup, groupFile)
+		if err != nil {
+			gid = 0
+			logger.WithError(err).WithField("group", groupname).Error("Error looking up fallback groupname, using 0")
+		}
 	}
+
 	return Ownership{
-		UID: uid,
-		GID: gid,
-	}, nil
+		UID:         uid,
+		GID:         gid,
+		userSource:  passwdFile,
+		groupSource: groupFile,
+	}
 }
 
 // lookupUID resolves a username to a numeric id.
-func lookupUID(username string) (uint32, error) {
+func lookupUID(username, passwdFile string) (uint32, error) {
 	uid, err := lookupIDInFile(username, passwdFile)
 	if err != nil {
 		return 0, fmt.Errorf("Error resolving uid for %s: %v\n", username, err)
@@ -58,7 +79,7 @@ func lookupUID(username string) (uint32, error) {
 }
 
 // lookupGID resolves a groupname to a numeric id.
-func lookupGID(groupname string) (uint32, error) {
+func lookupGID(groupname, groupFile string) (uint32, error) {
 	gid, err := lookupIDInFile(groupname, groupFile)
 	if err != nil {
 		return 0, fmt.Errorf("Error resolving gid for %s: %v\n", groupname, err)

--- a/secret.go
+++ b/secret.go
@@ -78,13 +78,13 @@ func (s Secret) ModeValue() (os.FileMode, error) {
 func (s Secret) OwnershipValue(fallback Ownership) (ownership Ownership) {
 	ownership = fallback
 	if s.Owner != "" {
-		uid, err := lookupUID(s.Owner)
+		uid, err := lookupUID(s.Owner, fallback.userSource)
 		if err == nil {
 			ownership.UID = uid
 		}
 	}
 	if s.Group != "" {
-		gid, err := lookupGID(s.Group)
+		gid, err := lookupGID(s.Group, fallback.groupSource)
 		if err == nil {
 			ownership.GID = gid
 		}

--- a/secret_test.go
+++ b/secret_test.go
@@ -85,27 +85,19 @@ func TestSecretModeValue(t *testing.T) {
 }
 
 func TestSecretOwnershipValue(t *testing.T) {
-	newAssert := assert.New(t)
-
-	groupFile = "fixtures/ownership/group"
-	defer func() { groupFile = "/etc/group" }()
-
-	passwdFile = "fixtures/ownership/passwd"
-	defer func() { passwdFile = "/etc/passwd" }()
-
-	defaultOwnership := Ownership{UID: 1, GID: 1}
+	defaultOwnership := Ownership{UID: 1, GID: 1, userSource: "fixtures/ownership/passwd", groupSource: "fixtures/ownership/group"}
 
 	ownership := Secret{Owner: "test0"}.OwnershipValue(defaultOwnership)
-	newAssert.EqualValues(ownership.UID, 1234)
-	newAssert.EqualValues(ownership.GID, 1)
+	assert.EqualValues(t, 1000, ownership.UID)
+	assert.EqualValues(t, 1, ownership.GID)
 
-	ownership = Secret{Owner: "test1", Group: "test2"}.OwnershipValue(defaultOwnership)
-	newAssert.EqualValues(ownership.UID, 1235)
-	newAssert.EqualValues(ownership.GID, 1236)
+	ownership = Secret{Owner: "test1", Group: "group2"}.OwnershipValue(defaultOwnership)
+	assert.EqualValues(t, 1001, ownership.UID)
+	assert.EqualValues(t, 2002, ownership.GID)
 
 	ownership = Secret{}.OwnershipValue(defaultOwnership)
-	newAssert.EqualValues(ownership.UID, 1)
-	newAssert.EqualValues(ownership.GID, 1)
+	assert.EqualValues(t, 1, ownership.UID)
+	assert.EqualValues(t, 1, ownership.GID)
 }
 
 func TestContentErrors(t *testing.T) {

--- a/syncer.go
+++ b/syncer.go
@@ -182,19 +182,17 @@ func (s *Syncer) buildClient(name string, clientConfig ClientConfig, metricsHand
 	if err != nil {
 		return nil, err
 	}
-	user := clientConfig.User
-	group := clientConfig.Group
-	if user == "" {
-		user = s.config.DefaultUser
-	}
-	if group == "" {
-		group = s.config.DefaultGroup
-	}
-	defaultOwnership, err := NewOwnership(user, group)
-	if err != nil {
-		// We log an error here but continue on.  The default of "0", root, is safe.
-		s.logger.WithError(err).Error("Failed getting default ownership")
-	}
+
+	defaultOwnership := NewOwnership(
+		clientConfig.User,
+		clientConfig.Group,
+		s.config.DefaultUser,
+		s.config.DefaultGroup,
+		s.config.PasswdFile,
+		s.config.GroupFile,
+		s.logger,
+	)
+
 	writeConfig := WriteConfig{
 		WriteDirectory:    filepath.Join(s.config.SecretsDir, clientConfig.DirName),
 		EnforceFilesystem: s.config.FsType,

--- a/syncer_test.go
+++ b/syncer_test.go
@@ -37,12 +37,6 @@ func cleanup(syncer *Syncer) {
 }
 
 func TestSyncerLoadClients(t *testing.T) {
-	groupFile = "fixtures/ownership/group"
-	defer func() { groupFile = "/etc/group" }()
-
-	passwdFile = "fixtures/ownership/passwd"
-	defer func() { passwdFile = "/etc/passwd" }()
-
 	config, err := LoadConfig("fixtures/configs/test-config.yaml")
 	require.Nil(t, err)
 
@@ -71,12 +65,6 @@ func TestSyncerLoadClientsError(t *testing.T) {
 }
 
 func TestSyncerBuildClient(t *testing.T) {
-	groupFile = "fixtures/ownership/group"
-	defer func() { groupFile = "/etc/group" }()
-
-	passwdFile = "fixtures/ownership/passwd"
-	defer func() { passwdFile = "/etc/passwd" }()
-
 	config, err := LoadConfig("fixtures/configs/test-config.yaml")
 	require.Nil(t, err)
 
@@ -135,12 +123,6 @@ func TestSyncerRandomDuration(t *testing.T) {
 }
 
 func TestSyncerRunSuccess(t *testing.T) {
-	groupFile = "fixtures/ownership/group"
-	defer func() { groupFile = "/etc/group" }()
-
-	passwdFile = "fixtures/ownership/passwd"
-	defer func() { passwdFile = "/etc/passwd" }()
-
 	server := createDefaultServer()
 	defer server.Close()
 
@@ -184,12 +166,6 @@ func TestNewSyncerFails(t *testing.T) {
 }
 
 func TestSyncerRunOnce(t *testing.T) {
-	groupFile = "fixtures/ownership/group"
-	defer func() { groupFile = "/etc/group" }()
-
-	passwdFile = "fixtures/ownership/passwd"
-	defer func() { passwdFile = "/etc/passwd" }()
-
 	server := createDefaultServer()
 	defer server.Close()
 


### PR DESCRIPTION
Make the fallback logic for uid/gid of files independent of each other
    
Before, if one of the user or group wasn't found, both the user and group used the fallback.  That isn't what was desired.
    
This also removes use of two global variables for the passwdFile and groupFile, which makes testing easier.
    
I've reorganized the tests a bit to match the new structure of the code.

I've also changed the test groups and users to verify there's no uid and gid and user and group confusion (there was before!)