### PR TITLE
Ownership cleanup

### DIFF
--- a/config.go
+++ b/config.go
@@ -49,7 +49,7 @@ type ClientConfig struct {
 	Cert    string `yaml:"cert"`      // Optional: PEM Certificate (If cert isn't in key file)
 	User    string `yaml:"user"`      // Optional: User and Group are defaults for files without metadata
 	DirName string `yaml:"directory"` // Optional: What directory under SecretsDir this client is in. Defaults to the client name.
-	Group   string `yaml:"group"`     // If unspecified, the global defaults are used.
+	Group   string `yaml:"group"`     // Optional: If unspecified, the global defaults are used.
 }
 
 // LoadConfig loads the "global" keysync configuration file.  This would generally be called on startup.

--- a/fixtures/ownership/group
+++ b/fixtures/ownership/group
@@ -3,3 +3,5 @@ group1:x:2001:test0,test1
 group2:x:2002:test0,test1
 badgroup:x:baddata:test0,test1
 keysync-test:x:2005:keysync-test
+# This is a group with an empty group name, to test we don't return it when no group is configured
+:x:9999:keysync-test

--- a/fixtures/ownership/passwd
+++ b/fixtures/ownership/passwd
@@ -3,3 +3,5 @@ test1:x:1001:2001:test1:/etc/test1:/sbin/nologin
 test2:x:1002:2002:test2:/var/lib/test0:/bin/bash
 baddata:x:baddata:2003:test2:/var/lib/test0:/bin/bash
 keysync-test:x:2005:keysync-test:/var/lib/test0:/bin/bash
+# This is a user with an empty username, to test we don't return it when no user is configured
+:x:9999:empty-username-badness:/test:/sbin/nologin

--- a/fixtures/ownership/passwd
+++ b/fixtures/ownership/passwd
@@ -1,4 +1,5 @@
 test0:x:1000:2000:test0:/test0:/bin/bash
+#test2:x:999:999:test0:/test:/bin/bash
 test1:x:1001:2001:test1:/etc/test1:/sbin/nologin
 test2:x:1002:2002:test2:/var/lib/test0:/bin/bash
 baddata:x:baddata:2003:test2:/var/lib/test0:/bin/bash

--- a/ownership.go
+++ b/ownership.go
@@ -104,7 +104,12 @@ func lookupIDInFile(name, fileName string) (uint32, error) {
 	defer file.Close()
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		entry := strings.Split(scanner.Text(), ":")
+		line := scanner.Text()
+		if trimmed := strings.TrimSpace(line); len(trimmed) == 0 || trimmed[0] == '#' {
+			// Skip empty and commented out lines.
+			continue
+		}
+		entry := strings.Split(line, ":")
 		if entry[0] == name && len(entry) >= 3 {
 			gid, err := strconv.ParseUint(entry[2], 10 /* base */, 32 /* bits */)
 			if err != nil {

--- a/ownership.go
+++ b/ownership.go
@@ -40,9 +40,13 @@ func NewOwnership(username, groupname, fallbackUser, fallbackGroup, passwdFile, 
 	var uid, gid uint32
 	var err error
 
-	uid, err = lookupUID(username, passwdFile)
+	if username != "" {
+		uid, err = lookupUID(username, passwdFile)
+	}
 	if err != nil {
 		logger.WithError(err).WithField("user", username).Error("Error looking up username, using fallback")
+	}
+	if username == "" || err != nil {
 		uid, err = lookupUID(fallbackUser, passwdFile)
 		if err != nil {
 			uid = 0
@@ -50,9 +54,13 @@ func NewOwnership(username, groupname, fallbackUser, fallbackGroup, passwdFile, 
 		}
 	}
 
-	gid, err = lookupGID(groupname, groupFile)
+	if groupname != "" {
+		gid, err = lookupGID(groupname, groupFile)
+	}
 	if err != nil {
 		logger.WithError(err).WithField("group", groupname).Error("Error looking up groupname, using fallback")
+	}
+	if groupname == "" || err != nil {
 		gid, err = lookupGID(fallbackGroup, groupFile)
 		if err != nil {
 			gid = 0

--- a/ownership_test.go
+++ b/ownership_test.go
@@ -56,6 +56,10 @@ func TestFallback(t *testing.T) {
 	ownership = NewOwnership("user-doesnt-exist", "group1", "user-doesnt-exist2", "", passwdFile, groupFile, testLog)
 	assert.EqualValues(t, 0, ownership.UID)
 	assert.EqualValues(t, 2001, ownership.GID)
+
+	ownership = NewOwnership("", "", "test2", "group2", passwdFile, groupFile, testLog)
+	assert.EqualValues(t, 1002, ownership.UID)
+	assert.EqualValues(t, 2002, ownership.GID)
 }
 
 // Verify we return an error if a file is missing

--- a/ownership_test.go
+++ b/ownership_test.go
@@ -80,6 +80,9 @@ func TestLookupFailure(t *testing.T) {
 
 	_, err = lookupUID("non-existent", groupFile)
 	assert.Error(t, err)
+
+	_, err = lookupUID("#test2", passwdFile)
+	assert.Error(t, err)
 }
 
 // Verify bad rows return an error.  Good rows are tested in all above tests


### PR DESCRIPTION
This should remove one of the common "harmless" errors in our logs.