### PR TITLE
Remove entries from oldClients after cleanup

### DIFF
--- a/syncer.go
+++ b/syncer.go
@@ -315,9 +315,11 @@ func (s *Syncer) RunOnce() []error {
 			errors = append(errors, err)
 			s.logger.WithError(err).WithField("name", name).Warn("Failed to remove old client")
 		} else {
-			delete(s.oldClients, name)
 			s.logger.WithField("name", name).Info("Removed old client")
 		}
+		// This is outside the error check, because we should only try to clean up
+		// once.  If it failed and still exists, the sweep below will catch it.
+		delete(s.oldClients, name)
 	}
 
 	// Clean up any old content in the secrets directory

--- a/syncer.go
+++ b/syncer.go
@@ -315,6 +315,7 @@ func (s *Syncer) RunOnce() []error {
 			errors = append(errors, err)
 			s.logger.WithError(err).WithField("name", name).Warn("Failed to remove old client")
 		} else {
+			delete(s.oldClients, name)
 			s.logger.WithField("name", name).Info("Removed old client")
 		}
 	}


### PR DESCRIPTION
This fixes issue #45

Because we didn't remove them from this list, we'd try to clean up after each
sync, even if the client had been recreated.

This is a bit annoying to test, so I'm going to refactor syncer and our tests
a bit to make this class of bug testable, however this is causing some problems
in production so I'd like to get this fix out before the weekend.