### PR TITLE
Refactor for output interface

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -106,7 +106,7 @@ func TestApiSyncOneError(t *testing.T) {
 	config, err := LoadConfig("fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml")
 	require.Nil(t, err)
 
-	syncer, err := NewSyncer(config, logrus.NewEntry(logrus.New()), metricsForTest())
+	syncer, err := NewSyncer(config, OutputDirCollection{}, logrus.NewEntry(logrus.New()), metricsForTest())
 	require.Nil(t, err)
 
 	err = syncer.LoadClients()
@@ -137,7 +137,7 @@ func TestHealthCheck(t *testing.T) {
 	config, err := LoadConfig("fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml")
 	require.Nil(t, err)
 
-	syncer, err := NewSyncer(config, logrus.NewEntry(logrus.New()), metricsForTest())
+	syncer, err := NewSyncer(config, OutputDirCollection{}, logrus.NewEntry(logrus.New()), metricsForTest())
 	require.Nil(t, err)
 
 	err = syncer.LoadClients()
@@ -170,7 +170,7 @@ func TestMetricsReporting(t *testing.T) {
 	config, err := LoadConfig("fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml")
 	require.Nil(t, err)
 
-	syncer, err := NewSyncer(config, logrus.NewEntry(logrus.New()), metricsForTest())
+	syncer, err := NewSyncer(config, OutputDirCollection{}, logrus.NewEntry(logrus.New()), metricsForTest())
 	require.Nil(t, err)
 
 	err = syncer.LoadClients()

--- a/cmd/keysync/keysync.go
+++ b/cmd/keysync/keysync.go
@@ -74,24 +74,26 @@ func main() {
 		}
 	}
 
-	raven.CapturePanicAndWait(func() {
-		metricsHandle := sqmetrics.NewMetrics("", config.MetricsPrefix, http.DefaultClient, 1*time.Second, metrics.DefaultRegistry, &stdlog.Logger{})
+	//raven.CapturePanicAndWait(func() {
+	metricsHandle := sqmetrics.NewMetrics("", config.MetricsPrefix, http.DefaultClient, 1*time.Second, metrics.DefaultRegistry, &stdlog.Logger{})
 
-		syncer, err := keysync.NewSyncer(config, logger, metricsHandle)
-		if err != nil {
-			logger.WithError(err).Fatal("Failed while creating syncer")
-		}
+	syncer, err := keysync.NewSyncer(config, keysync.OutputDirCollection{config}, logger, metricsHandle)
+	if err != nil {
+		logger.WithError(err).Fatal("Failed while creating syncer")
+	}
 
-		// Start the API server
-		if config.APIPort != 0 {
-			keysync.NewAPIServer(syncer, config.APIPort, logger, metricsHandle)
-		}
+	// Start the API server
+	if config.APIPort != 0 {
+		keysync.NewAPIServer(syncer, config.APIPort, logger, metricsHandle)
+	}
 
-		err = syncer.Run()
-		if err != nil {
-			logger.WithError(err).Fatal("Failed while running syncer")
-		}
-	}, nil)
+	logger.Info("Starting syncer")
+	err = syncer.Run()
+	if err != nil {
+		logger.WithError(err).Fatal("Failed while running syncer")
+	}
+	//}, nil)
+	logger.Info("exiting")
 }
 
 // This is modified from raven.newTransport()

--- a/write.go
+++ b/write.go
@@ -15,21 +15,175 @@
 package keysync
 
 import (
+	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/Sirupsen/logrus"
 )
 
-// WriteConfig stores the options for atomicWrite
-type WriteConfig struct {
+// OutputCollection handles a collection of outputs.
+type OutputCollection interface {
+	NewOutput(clientConfig ClientConfig, logger *logrus.Entry) (Output, error)
+	// Cleanup unknown clients (eg, ones deleted while keysync was not running)
+	Cleanup(map[string]struct{}, *logrus.Entry) []error
+}
+
+// Output is an interface that encapsulates what it means to store secrets
+type Output interface {
+	// Validate returns true if the secret is persisted already
+	Validate(secret *Secret, state secretState) bool
+	// Write a secret
+	Write(secret *Secret) (*secretState, error)
+	// Remove a secret
+	Remove(name string) error
+	// Remove all secrets and the containing directory (eg, when the client config is removed)
+	RemoveAll() error
+	// Cleanup unknown files (eg, ones deleted in Keywhiz while keysync was not running)
+	Cleanup(map[string]secretState) error
+}
+
+type OutputDirCollection struct {
+	Config *Config
+}
+
+func (c OutputDirCollection) NewOutput(clientConfig ClientConfig, logger *logrus.Entry) (Output, error) {
+	defaultOwnership := NewOwnership(
+		clientConfig.User,
+		clientConfig.Group,
+		c.Config.DefaultUser,
+		c.Config.DefaultGroup,
+		c.Config.PasswdFile,
+		c.Config.GroupFile,
+		logger,
+	)
+
+	writeDirectory := filepath.Join(c.Config.SecretsDir, clientConfig.DirName)
+	if err := os.MkdirAll(writeDirectory, 0775); err != nil {
+		return nil, fmt.Errorf("Making client directory '%s': %v", writeDirectory, err)
+	}
+
+	return &OutputDir{
+		WriteDirectory:    writeDirectory,
+		EnforceFilesystem: c.Config.FsType,
+		ChownFiles:        c.Config.ChownFiles,
+		DefaultOwnership:  defaultOwnership,
+		Logger:            logger,
+	}, nil
+}
+
+func (c OutputDirCollection) Cleanup(known map[string]struct{}, logger *logrus.Entry) []error {
+	var errors []error
+
+	fileInfos, err := ioutil.ReadDir(c.Config.SecretsDir)
+	if err != nil {
+		errors = append(errors, err)
+		logger.WithError(err).WithField("SecretsDir", c.Config.SecretsDir).Warn("Couldn't read secrets dir")
+	}
+	for _, fileInfo := range fileInfos {
+		if !fileInfo.IsDir() {
+			logger.WithField("name", fileInfo.Name()).Warn("Found unknown file, ignoring")
+			continue
+		}
+		if _, present := known[fileInfo.Name()]; !present {
+			logger.WithField("name", fileInfo.Name()).WithField("known", known).Warn("Deleting unknown directory")
+			os.RemoveAll(filepath.Join(c.Config.SecretsDir, fileInfo.Name()))
+		}
+	}
+
+	return errors
+}
+
+// OutputDir implements Output to files, which is the typical keysync usage to a tmpfs.
+type OutputDir struct {
 	WriteDirectory    string
 	DefaultOwnership  Ownership
 	EnforceFilesystem Filesystem // What filesystem type do we expect to write to?
 	ChownFiles        bool       // Do we chown the file? (Needs root or CAP_CHOWN).
+	Logger            *logrus.Entry
+}
+
+// Validate verifies the secret is written to disk with the correct content, permissions, and ownership
+func (out *OutputDir) Validate(secret *Secret, state secretState) bool {
+	if state.Checksum != secret.Checksum {
+		return false
+	}
+	path := filepath.Join(out.WriteDirectory, secret.Name)
+
+	// Check if new permissions match state
+	if state.Owner != secret.Owner || state.Group != secret.Group || state.Mode != secret.Mode {
+		return false
+	}
+
+	// Check on-disk permissions, and ownership against what's configured.
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	fileinfo, err := GetFileInfo(f)
+	if err != nil {
+		return false
+	}
+	if state.FileInfo != *fileinfo {
+		out.Logger.WithFields(logrus.Fields{
+			"secret":   secret.Name,
+			"expected": state.FileInfo,
+			"seen":     *fileinfo,
+		}).Warn("Secret permissions changed unexpectedly")
+		return false
+	}
+
+	// Check the content of what's on disk
+	var b bytes.Buffer
+	_, err = b.ReadFrom(f)
+	if err != nil {
+		return false
+	}
+	hash := sha256.Sum256(b.Bytes())
+
+	if state.ContentHash != hash {
+		// As tempting as it is, we shouldn't log hashes as they'd leak information about the secret.
+		out.Logger.WithField("secret", secret.Name).Warn("Secret modified on disk")
+		return false
+	}
+
+	// OK, the file is unchanged
+	return true
+
+}
+
+func (out *OutputDir) Remove(name string) error {
+	return os.Remove(filepath.Join(out.WriteDirectory, name))
+}
+
+func (out *OutputDir) RemoveAll() error {
+	return os.RemoveAll(out.WriteDirectory)
+}
+
+func (out *OutputDir) Cleanup(knownState map[string]secretState) error {
+	fileInfos, err := ioutil.ReadDir(out.WriteDirectory)
+	if err != nil {
+		return fmt.Errorf("Couldn't read directory: %s\n", out.WriteDirectory)
+	}
+	for _, fileInfo := range fileInfos {
+		existingFile := fileInfo.Name()
+		if _, present := knownState[existingFile]; !present {
+			// This file wasn't written in the loop above, so we remove it.
+			out.Logger.WithField("file", existingFile).Info("Removing unknown file")
+			err := os.Remove(filepath.Join(out.WriteDirectory, existingFile))
+			if err != nil {
+				out.Logger.WithError(err).Warnf("Unable to delete file")
+			}
+		}
+	}
+	return nil
 }
 
 // FileInfo returns the filesystem properties atomicWrite wrote
@@ -58,7 +212,7 @@ func GetFileInfo(file *os.File) (*FileInfo, error) {
 // 2. Nobody observes a partially-overwritten secret file.
 // Since keysync is intended to write to tmpfs, this function doesn't do the necessary fsyncs if it
 // were persisting content to disk.
-func atomicWrite(_ string, secret *Secret, writeConfig WriteConfig) (*FileInfo, error) {
+func (out *OutputDir) Write(secret *Secret) (*secretState, error) {
 	if strings.ContainsRune(secret.Name, filepath.Separator) {
 		// This prevents a secret named "../../etc/passwd" from being written outside this directory
 		return nil, fmt.Errorf("Cannot write: %s contains %c", secret.Name, filepath.Separator)
@@ -70,7 +224,7 @@ func atomicWrite(_ string, secret *Secret, writeConfig WriteConfig) (*FileInfo, 
 		return nil, err
 	}
 	randSuffix := hex.EncodeToString(buf)
-	fullPath := filepath.Join(writeConfig.WriteDirectory, secret.Name)
+	fullPath := filepath.Join(out.WriteDirectory, secret.Name)
 	f, err := os.OpenFile(fullPath+randSuffix, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0000)
 	// Try to remove the file, in event we early-return with an error.
 	defer os.Remove(fullPath + randSuffix)
@@ -78,8 +232,8 @@ func atomicWrite(_ string, secret *Secret, writeConfig WriteConfig) (*FileInfo, 
 		return nil, err
 	}
 
-	if writeConfig.ChownFiles {
-		ownership := secret.OwnershipValue(writeConfig.DefaultOwnership)
+	if out.ChownFiles {
+		ownership := secret.OwnershipValue(out.DefaultOwnership)
 
 		err = f.Chown(int(ownership.UID), int(ownership.GID))
 		if err != nil {
@@ -99,8 +253,8 @@ func atomicWrite(_ string, secret *Secret, writeConfig WriteConfig) (*FileInfo, 
 
 	}
 
-	if writeConfig.EnforceFilesystem != 0 {
-		good, err := isFilesystem(f, writeConfig.EnforceFilesystem)
+	if out.EnforceFilesystem != 0 {
+		good, err := isFilesystem(f, out.EnforceFilesystem)
 		if err != nil {
 			return nil, fmt.Errorf("Checking filesystem type: %v", err)
 		}
@@ -124,7 +278,15 @@ func atomicWrite(_ string, secret *Secret, writeConfig WriteConfig) (*FileInfo, 
 	if err != nil {
 		return nil, err
 	}
-	return filemode, nil
+	state := secretState{
+		ContentHash: sha256.Sum256(secret.Content),
+		Checksum:    secret.Checksum,
+		FileInfo:    *filemode,
+		Owner:       secret.Owner,
+		Group:       secret.Group,
+		Mode:        secret.Mode,
+	}
+	return &state, err
 }
 
 // The Filesystem identification.  On Mac, this is uint32, and int64 on linux

--- a/write_test.go
+++ b/write_test.go
@@ -1,0 +1,144 @@
+package keysync
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func testConfig(t *testing.T) Config {
+	dir, err := ioutil.TempDir("", "keysyncWriteTest")
+	assert.NoError(t, err, "Error making tempdir")
+
+	return Config{
+		SecretsDir: dir,
+		ChownFiles: false,
+		PasswdFile: "fixtures/ownership/passwd",
+		GroupFile:  "fixtures/ownership/group",
+	}
+}
+
+func testClientConfig(name string) ClientConfig {
+	return ClientConfig{
+		Key:     fmt.Sprintf("fixtures/clients/%s.key", name),
+		Cert:    fmt.Sprintf("fixtures/clients/%s.crt", name),
+		DirName: name,
+	}
+}
+
+func testSecret(name string) Secret {
+	return Secret{
+		Name:     name,
+		Content:  []byte("my secret content"),
+		Checksum: "0ABC",
+	}
+}
+
+func testFixture(t *testing.T) (Config, ClientConfig, OutputDirCollection, Output) {
+	c := testConfig(t)
+
+	testlogger := testLogger()
+
+	odc := OutputDirCollection{Config: &c}
+	cc := testClientConfig("client 1")
+	out, err := odc.NewOutput(cc, testlogger)
+	assert.NoError(t, err)
+
+	return c, cc, odc, out
+}
+
+func testLogger() *logrus.Entry {
+	return logrus.NewEntry(logrus.New())
+}
+
+// Test the basic secret lifecycle:
+// Calls all methods in the OutputCollection and Output interface
+func TestBasicLifecycle(t *testing.T) {
+	c, _, odc, out := testFixture(t)
+	defer os.RemoveAll(c.SecretsDir)
+
+	odc.Cleanup(map[string]struct{}{"client 1": {}}, testLogger())
+
+	name := "secret 1"
+	s := testSecret(name)
+
+	state, err := out.Write(&s)
+	assert.NoError(t, err)
+
+	assert.NoError(t, out.Cleanup(map[string]secretState{name: *state}))
+
+	assert.True(t, out.Validate(&s, *state), "Expected just-written secret to be valid")
+
+	filecontents, err := ioutil.ReadFile(filepath.Join(c.SecretsDir, "client 1", name))
+	assert.NoError(t, err)
+
+	assert.Equal(t, s.Content, content(filecontents))
+
+	assert.NoError(t, out.Remove(name))
+
+	assert.False(t, out.Validate(&s, *state), "Expected secret invalid after deletion")
+
+	assert.NoError(t, out.RemoveAll())
+}
+
+// Test that if ChownFiles is set, we fail to write out files (since we're not root)
+// While this isn't a super-great test, it makes sure ChownFiles = true does something.
+func TestChownFiles(t *testing.T) {
+	c, _, _, out := testFixture(t)
+	defer os.RemoveAll(c.SecretsDir)
+
+	// Easier to modify this after-the-fact so we can share test fixture setup
+	out.(*OutputDir).ChownFiles = true
+
+	secret := testSecret("secret")
+	_, err := out.Write(&secret)
+	assert.Error(t, err, "Expected error writing file.  Maybe you're testing as root?")
+}
+
+// This tests enforcing filesystems.  We set an EnforceFilesystem value that won't correspond with any filesystem
+// we might run tests on, and thus we should never succeed in writing files.
+func TestEnforceFS(t *testing.T) {
+	c, _, _, out := testFixture(t)
+	defer os.RemoveAll(c.SecretsDir)
+
+	// Easier to modify this after-the-fact so we can share test fixture setup
+	// This value is Linux's /proc filesystem, arbitrarily chosen as a filesystem we're not going to be writing to,
+	// so that out.Write is guaranteed to fail.
+	out.(*OutputDir).EnforceFilesystem = 0x9fa0
+
+	secret := testSecret("secret")
+	_, err := out.Write(&secret)
+	assert.EqualError(t, err, "Unexpected filesystem writing secret")
+}
+
+// Make sure any stray files and directories are cleaned up by Keysync.
+func TestCleanup(t *testing.T) {
+	c, cc, odc, out := testFixture(t)
+	defer os.RemoveAll(c.SecretsDir)
+
+	junkdir := filepath.Join(c.SecretsDir, "junk client")
+	assert.NoError(t, os.MkdirAll(junkdir, 0400))
+
+	_, err := os.Stat(junkdir)
+	assert.NoError(t, err, "Expected junkdir to exist before cleanup")
+
+	errs := odc.Cleanup(map[string]struct{}{cc.DirName: {}}, testLogger())
+	assert.Equal(t, 0, len(errs), "Expected no errors cleaning up")
+
+	_, err = os.Stat(junkdir)
+	assert.Error(t, err, "Expected junkdir to be gone after cleanup")
+
+	junkfile := filepath.Join(c.SecretsDir, cc.DirName, "junk file")
+	assert.NoError(t, ioutil.WriteFile(junkfile, []byte("my data"), 0400))
+
+	assert.NoError(t, out.Cleanup(map[string]secretState{"secret 1": {}}))
+
+	_, err = os.Stat(junkfile)
+	assert.Error(t, err, "Expected file to be gone after cleanup")
+}


### PR DESCRIPTION
This splits everything related to writing to the filesystem out of syncer.go and into write.go

This means we can test the tricky file-output stuff seperately from the tricky state-machine stuff in the syncer.  It also makes it way easier to test without worrying about temp files, etc.

At a high level:

There's a new "OutputCollection" which models the top-level secretsdir, and it has an "Output" for each client directory within it.  There's an interface and concrete implementation, plus an "in memory" implementation that's used in syncer tests.

This should enable some more changes I want to be easier, but I think this PR is already pretty big so I'd best merge this before going too much further.