### PR TITLE
Remove panic from main function

### DIFF
--- a/cmd/keysync/keysync.go
+++ b/cmd/keysync/keysync.go
@@ -75,7 +75,6 @@ func main() {
 	}
 
 	captured, errorId := raven.CapturePanicAndWait(func() {
-		panic("hi friends")
 		metricsHandle := sqmetrics.NewMetrics("", config.MetricsPrefix, http.DefaultClient, 1*time.Second, metrics.DefaultRegistry, &stdlog.Logger{})
 
 		syncer, err := keysync.NewSyncer(config, keysync.OutputDirCollection{config}, logger, metricsHandle)


### PR DESCRIPTION
In the last PR I merged, I had intended to test some changes to panic handling
so put a panic in the main function.  I should have removed it before merging.