### PR TITLE
Support custom filenames in metadata

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -42,7 +42,7 @@ func NewBackupBundleClient(path string, logger *logrus.Entry) (Client, error) {
 	}
 
 	for _, secret := range parsed {
-		client.secrets[secret.Name] = secret
+		client.secrets[secret.Filename()] = secret
 	}
 
 	return &client, nil

--- a/client.go
+++ b/client.go
@@ -238,7 +238,7 @@ func (c KeywhizHTTPClient) SecretList() (map[string]Secret, error) {
 	}
 	secrets := map[string]Secret{}
 	for _, secret := range secretList {
-		secrets[secret.Name] = secret
+		secrets[secret.Filename()] = secret
 	}
 	return secrets, nil
 }

--- a/client.go
+++ b/client.go
@@ -238,7 +238,13 @@ func (c KeywhizHTTPClient) SecretList() (map[string]Secret, error) {
 	}
 	secrets := map[string]Secret{}
 	for _, secret := range secretList {
-		secrets[secret.Filename()] = secret
+		filename := secret.Filename()
+		if duplicate, ok := secrets[filename]; ok {
+			// This is not supported by Keysync. This stops syncing until the data inconsistency is fixed in the server.
+			return nil, fmt.Errorf("Duplicate filename detected: %s on secrets %s and %s",
+				filename, duplicate.Name, secret.Name)
+		}
+		secrets[filename] = secret
 	}
 	return secrets, nil
 }

--- a/secret.go
+++ b/secret.go
@@ -47,15 +47,16 @@ func ParseSecretList(data []byte) (secrets []Secret, err error) {
 //
 // json tags after fields indicate to json decoder the key name in JSON
 type Secret struct {
-	Name      string
-	Content   content   `json:"secret"`
-	Length    uint64    `json:"secretLength"`
-	Checksum  string    `json:"checksum"`
-	CreatedAt time.Time `json:"creationDate"`
-	UpdatedAt time.Time `json:"updateDate"`
-	Mode      string
-	Owner     string
-	Group     string
+	Name             string
+	Content          content   `json:"secret"`
+	Length           uint64    `json:"secretLength"`
+	Checksum         string    `json:"checksum"`
+	CreatedAt        time.Time `json:"creationDate"`
+	UpdatedAt        time.Time `json:"updateDate"`
+	FilenameOverride *string   `json:"filename"`
+	Mode             string
+	Owner            string
+	Group            string
 }
 
 // ModeValue function helps by converting a textual mode to the expected value for fuse.
@@ -90,6 +91,14 @@ func (s Secret) OwnershipValue(fallback Ownership) (ownership Ownership) {
 		}
 	}
 	return
+}
+
+// Filename returns the expected filename of a secret:  The filename metadata overrides the name
+func (s Secret) Filename() string {
+	if s.FilenameOverride != nil {
+		return *s.FilenameOverride
+	}
+	return s.Name
 }
 
 // content is a helper type used to convert base64-encoded data from the server.

--- a/util_test.go
+++ b/util_test.go
@@ -157,7 +157,7 @@ func (out InMemoryOutput) RemoveAll() error {
 	return nil
 }
 
-func (out InMemoryOutput) Cleanup(_ map[string]secretState) error {
+func (out InMemoryOutput) Cleanup(_ map[string]Secret) error {
 	return nil
 }
 


### PR DESCRIPTION
Changes:

1. Make client.SecretList() return a map of filenames to secrets.

2. Explicitly use the secretMetadata.Name in syncer when needed to request
   the actual secret from the server.

3. Change the cleanup function to take the output of client.SecretList(),
   which avoids using the internal state of the syncer.  It also means we
   don't need to put a bogus entry into that state if there was a server error
   when we requested it, which reduces some complexity.