### PR TITLE
Always mkdir before writing a secret

### DIFF
--- a/write.go
+++ b/write.go
@@ -66,9 +66,6 @@ func (c OutputDirCollection) NewOutput(clientConfig ClientConfig, logger *logrus
 	)
 
 	writeDirectory := filepath.Join(c.Config.SecretsDir, clientConfig.DirName)
-	if err := os.MkdirAll(writeDirectory, 0775); err != nil {
-		return nil, fmt.Errorf("Making client directory '%s': %v", writeDirectory, err)
-	}
 
 	return &OutputDir{
 		WriteDirectory:    writeDirectory,
@@ -219,6 +216,11 @@ func (out *OutputDir) Write(secret *Secret) (*secretState, error) {
 		// This prevents a secret named "../../etc/passwd" from being written outside this directory
 		return nil, fmt.Errorf("Cannot write: %s contains %c", filename, filepath.Separator)
 	}
+
+	if err := os.MkdirAll(out.WriteDirectory, 0775); err != nil {
+		return nil, fmt.Errorf("Making client directory '%s': %v", out.WriteDirectory, err)
+	}
+
 	// We can't use ioutil.TempFile because we want to open 0000.
 	buf := make([]byte, 32)
 	_, err := rand.Read(buf)

--- a/write.go
+++ b/write.go
@@ -66,6 +66,9 @@ func (c OutputDirCollection) NewOutput(clientConfig ClientConfig, logger *logrus
 	)
 
 	writeDirectory := filepath.Join(c.Config.SecretsDir, clientConfig.DirName)
+	if err := os.MkdirAll(writeDirectory, 0775); err != nil {
+		return nil, fmt.Errorf("Making client directory '%s': %v", writeDirectory, err)
+	}
 
 	return &OutputDir{
 		WriteDirectory:    writeDirectory,


### PR DESCRIPTION
mkdir is absurdly cheap, and this avoids any issues potentially caused by
tmpfs deletion or otherwise the folder being missing.  We should be as robust
as possible to any on-disk state.