### PR TITLE
Get override filename from metadata instead of top-level

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -235,8 +235,8 @@ func TestDuplicateFilenames(t *testing.T) {
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/secrets"):
-			fmt.Fprint(w, `[{"name" : "SecretA", "filename": "overridden_filename"},
-			 {"name" : "SecretB", "filename": "overridden_filename"}]`)
+			fmt.Fprint(w, `[{"name" : "SecretA", "metadata":{"filename": "overridden_filename"}},
+			{"name" : "SecretB", "metadata":{"filename": "overridden_filename"}}]`)
 		default:
 			w.WriteHeader(404)
 		}

--- a/secret.go
+++ b/secret.go
@@ -47,16 +47,16 @@ func ParseSecretList(data []byte) (secrets []Secret, err error) {
 //
 // json tags after fields indicate to json decoder the key name in JSON
 type Secret struct {
-	Name             string
-	Content          content   `json:"secret"`
-	Length           uint64    `json:"secretLength"`
-	Checksum         string    `json:"checksum"`
-	CreatedAt        time.Time `json:"creationDate"`
-	UpdatedAt        time.Time `json:"updateDate"`
-	FilenameOverride *string   `json:"filename"`
-	Mode             string
-	Owner            string
-	Group            string
+	Name      string
+	Content   content           `json:"secret"`
+	Length    uint64            `json:"secretLength"`
+	Checksum  string            `json:"checksum"`
+	CreatedAt time.Time         `json:"creationDate"`
+	UpdatedAt time.Time         `json:"updateDate"`
+	Metadata  map[string]string `json:"metadata"`
+	Mode      string
+	Owner     string
+	Group     string
 }
 
 // ModeValue function helps by converting a textual mode to the expected value for fuse.
@@ -95,8 +95,10 @@ func (s Secret) OwnershipValue(fallback Ownership) (ownership Ownership) {
 
 // Filename returns the expected filename of a secret:  The filename metadata overrides the name
 func (s Secret) Filename() string {
-	if s.FilenameOverride != nil {
-		return *s.FilenameOverride
+	if s.Metadata != nil {
+		if override, ok := s.Metadata["filename"]; ok {
+			return override
+		}
 	}
 	return s.Name
 }

--- a/write_test.go
+++ b/write_test.go
@@ -150,7 +150,9 @@ func TestCustomFilename(t *testing.T) {
 
 	secret := testSecret("secret_name")
 	filename := "override_filename"
-	secret.FilenameOverride = &filename
+	secret.Metadata = map[string]string{
+		"filename": filename,
+	}
 
 	state, err := out.Write(&secret)
 	assert.NoError(t, err)


### PR DESCRIPTION
Get override filename from metadata instead of top-level