### PR TITLE
Onboarding tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 fixtures/clients/client[1-4]
+testing/secrets
+keysync
+keyrestore

--- a/README.md
+++ b/README.md
@@ -10,3 +10,39 @@ Keysync is a program for accessing secrets in [Keywhiz](https://github.com/squar
 It is currently under development, and not yet ready for use.
 
 It is intended as a replacement for the FUSE-based [keywhiz-fs](https://github.com/square/keywhiz-fs).
+
+## Getting Started
+
+### Building
+
+Keysync must be built with Go 1.9+. You can build keysync from source:
+
+```
+$ git clone https://github.com/square/keysync
+$ cd keysync
+$ ./build.sh
+```
+
+This will generate a binary called `./bin/keysync`
+
+### Testing
+
+Entire test suite:
+
+```
+go test
+```
+
+Short, unit tests only:
+
+```
+go test -short
+```
+
+### Running locally
+
+Keysync requires access to Keywhiz to work properly. Assuming you run Keywhiz locally on default port (4444), you can start keysync with:
+
+```
+./keysync --config keysync-config.yaml
+```

--- a/api_test.go
+++ b/api_test.go
@@ -57,6 +57,10 @@ func waitForServer(t *testing.T, port uint16) {
 }
 
 func TestApiSyncAllAndSyncClientSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping API test in short mode.")
+	}
+
 	port := randomPort()
 
 	server := createDefaultServer()
@@ -118,6 +122,10 @@ func TestApiSyncAllAndSyncClientSuccess(t *testing.T) {
 }
 
 func TestApiSyncOneError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping API test in short mode.")
+	}
+
 	port := randomPort()
 
 	config, err := LoadConfig("fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml")
@@ -150,6 +158,10 @@ func TestApiSyncOneError(t *testing.T) {
 }
 
 func TestHealthCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping API test in short mode.")
+	}
+
 	port := randomPort()
 
 	config, err := LoadConfig("fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml")
@@ -184,6 +196,10 @@ func TestHealthCheck(t *testing.T) {
 }
 
 func TestMetricsReporting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping API test in short mode.")
+	}
+
 	port := randomPort()
 
 	config, err := LoadConfig("fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml")

--- a/keysync-sample-config.yaml
+++ b/keysync-sample-config.yaml
@@ -1,0 +1,14 @@
+---
+secrets_directory: './testing/secrets'
+client_directory: './testing/clients'
+ca_file: './testing/cacert.crt'
+yaml_ext: yaml
+chown_files: false
+server: 'localhost:4444'
+debug: true
+default_user: 'keysync-test'
+default_group: 'keysync-test'
+passwd_file: '/etc/passwd'
+group_file: '/etc/group'
+api_port: 31738
+poll_interval: 1s


### PR DESCRIPTION
Summary
- instructions to get started in README
- use of `-short` flag for < 1s test suite run
- default dev config that works out of the box with keywhiz