### PR TITLE
More robust sync mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ $ ./build.sh
 
 This will generate a binary called `./bin/keysync`
 
+#### Dependencies
+
+Keysync uses [gvt](https://github.com/FiloSottile/gvt) to manage dependencies. All deps should be added using `gvt fetch` and committed into `vendor` directory.
+
 ### Testing
 
 Entire test suite:

--- a/client_test.go
+++ b/client_test.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/square/go-sq-metrics"
@@ -35,6 +34,17 @@ var (
 	testCaFile = "fixtures/CA/localhost.crt"
 )
 
+func defaultClientConfig() *ClientConfig {
+	return &ClientConfig{
+		Key:        clientKey,
+		Cert:       clientCert,
+		MaxRetries: 1,
+		Timeout:    "1s",
+		MinBackoff: "1ms",
+		MaxBackoff: "10ms",
+	}
+}
+
 func TestClientCallsServer(t *testing.T) {
 	newAssert := assert.New(t)
 
@@ -42,7 +52,7 @@ func TestClientCallsServer(t *testing.T) {
 	defer server.Close()
 
 	serverURL, _ := url.Parse(server.URL)
-	client, err := NewClient(clientCert, clientKey, testCaFile, serverURL, time.Second, 1, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
+	client, err := NewClient(defaultClientConfig(), testCaFile, serverURL, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
 	require.Nil(t, err)
 
 	secrets, err := client.SecretList()
@@ -68,7 +78,7 @@ func TestClientCallsServer(t *testing.T) {
 
 func TestClientRebuild(t *testing.T) {
 	serverURL, _ := url.Parse("http://dummy:8080")
-	client, err := NewClient(clientCert, clientKey, testCaFile, serverURL, time.Second, 1, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
+	client, err := NewClient(defaultClientConfig(), testCaFile, serverURL, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
 	require.Nil(t, err)
 
 	http1 := client.(*KeywhizHTTPClient).httpClient
@@ -99,7 +109,7 @@ func TestClientCallsServerErrors(t *testing.T) {
 	defer server.Close()
 
 	serverURL, _ := url.Parse(server.URL)
-	client, err := NewClient(clientCert, clientKey, testCaFile, serverURL, time.Second, 1, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
+	client, err := NewClient(defaultClientConfig(), testCaFile, serverURL, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
 	require.Nil(t, err)
 
 	secrets, err := client.SecretList()
@@ -156,7 +166,9 @@ func TestClientCallsServerIntermittentErrors(t *testing.T) {
 	defer server.Close()
 
 	serverURL, _ := url.Parse(server.URL)
-	client, err := NewClient(clientCert, clientKey, testCaFile, serverURL, time.Second, 2, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
+	cfg := defaultClientConfig()
+	cfg.MaxRetries = 2
+	client, err := NewClient(cfg, testCaFile, serverURL, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
 	require.Nil(t, err)
 
 	secrets, err := client.SecretList()
@@ -183,7 +195,7 @@ func TestClientCorruptedResponses(t *testing.T) {
 	defer server.Close()
 
 	serverURL, _ := url.Parse(server.URL)
-	client, err := NewClient(clientCert, clientKey, testCaFile, serverURL, time.Second, 1, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
+	client, err := NewClient(defaultClientConfig(), testCaFile, serverURL, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
 	require.Nil(t, err)
 
 	_, err = client.SecretList()
@@ -202,7 +214,7 @@ func TestClientParsingError(t *testing.T) {
 	defer server.Close()
 
 	serverURL, _ := url.Parse(server.URL)
-	client, err := NewClient(clientCert, clientKey, testCaFile, serverURL, time.Second, 1, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
+	client, err := NewClient(defaultClientConfig(), testCaFile, serverURL, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
 	require.Nil(t, err)
 
 	secrets, err := client.SecretList()
@@ -224,7 +236,7 @@ func TestClientServerStatusSuccess(t *testing.T) {
 	defer server.Close()
 
 	serverURL, _ := url.Parse(server.URL)
-	client, err := NewClient(clientCert, clientKey, testCaFile, serverURL, time.Second, 1, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
+	client, err := NewClient(defaultClientConfig(), testCaFile, serverURL, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
 	require.Nil(t, err)
 
 	_, err = client.(*KeywhizHTTPClient).ServerStatus()
@@ -234,7 +246,7 @@ func TestClientServerStatusSuccess(t *testing.T) {
 func TestClientServerFailure(t *testing.T) {
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	serverURL, _ := url.Parse(server.URL)
-	client, err := NewClient(clientCert, clientKey, testCaFile, serverURL, time.Second, 1, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
+	client, err := NewClient(defaultClientConfig(), testCaFile, serverURL, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
 	require.Nil(t, err)
 
 	_, err = client.(*KeywhizHTTPClient).ServerStatus()
@@ -260,7 +272,10 @@ func TestNewClientFailure(t *testing.T) {
 	// Try to load a client with an invalid CA file configured
 	clientName := "client1"
 	serverURL, _ := url.Parse(server.URL)
-	_, err = NewClient(clientConfigs[clientName].Cert, clientConfigs[clientName].Key, config.CaFile, serverURL, time.Second, 1, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
+	cfg := defaultClientConfig()
+	cfg.Cert = clientConfigs[clientName].Cert
+	cfg.Key = clientConfigs[clientName].Key
+	_, err = NewClient(cfg, config.CaFile, serverURL, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
 	assert.NotNil(t, err)
 }
 
@@ -279,7 +294,7 @@ func TestDuplicateFilenames(t *testing.T) {
 	defer server.Close()
 
 	serverURL, _ := url.Parse(server.URL)
-	client, err := NewClient(clientCert, clientKey, testCaFile, serverURL, time.Second, 1, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
+	client, err := NewClient(defaultClientConfig(), testCaFile, serverURL, logrus.NewEntry(logrus.New()), &sqmetrics.SquareMetrics{})
 	require.Nil(t, err)
 
 	_, err = client.SecretList()

--- a/cmd/keyrestore/keyrestore.go
+++ b/cmd/keyrestore/keyrestore.go
@@ -37,8 +37,8 @@ func main() {
 	var (
 		app        = kingpin.New("keyrestore", "Unpack and install a Keywhiz backup bundle")
 		configFile = app.Flag("config", "The base YAML configuration file").PlaceHolder("config.yaml").Required().ExistingFile()
-		user       = app.Flag("user", "Default user to install files as (unless overriden in bundle)").PlaceHolder("USER").Required().String()
-		group      = app.Flag("group", "Default group to install files as (unless overriden in bundle)").PlaceHolder("GROUP").Required().String()
+		user       = app.Flag("user", "Default user to install files as (unless overridden in bundle)").PlaceHolder("USER").Required().String()
+		group      = app.Flag("group", "Default group to install files as (unless overridden in bundle)").PlaceHolder("GROUP").Required().String()
 		dirName    = app.Flag("dir-name", "Directory (under the global secrets directory) to install files into").PlaceHolder("NAME").Required().String()
 		bundleFile = app.Arg("bundle", "Keywhiz backup bundle (JSON)").Required().ExistingFile()
 	)

--- a/config.go
+++ b/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	CaFile        string     `yaml:"ca_file"`           // The CA to trust (PEM)
 	YamlExt       string     `yaml:"yaml_ext"`          // The filename extension of the yaml config files
 	PollInterval  string     `yaml:"poll_interval"`     // If specified, poll at the given interval, otherwise, exit after syncing
+	MaxRetries    uint16     `yaml:"max_retries"`       // If specified, retry each HTTP call after non-200 response
 	Server        string     `yaml:"server"`            // The server to connect to (host:port)
 	Debug         bool       `yaml:"debug"`             // Enable debugging output
 	DefaultUser   string     `yaml:"default_user"`      // Default user to own files
@@ -74,6 +75,10 @@ func LoadConfig(configFile string) (*Config, error) {
 
 	if config.GroupFile == "" {
 		config.GroupFile = "/etc/group"
+	}
+
+	if config.MaxRetries < 1 {
+		config.MaxRetries = 1
 	}
 
 	return &config, nil

--- a/config_test.go
+++ b/config_test.go
@@ -89,6 +89,11 @@ func TestConfigLoadClientsSuccess(t *testing.T) {
 	newAssert.Equal("fixtures/clients/client1.crt", client.Cert)
 	newAssert.Equal("test-user", client.User)
 	newAssert.Equal("test-group", client.Group)
+	// defaults inherited from kesync's config
+	newAssert.Equal("23ms", client.MinBackoff)
+	newAssert.Equal("87ms", client.MaxBackoff)
+	newAssert.Equal("60s", client.Timeout)
+	newAssert.Equal(uint16(1), client.MaxRetries)
 }
 
 func TestConfigLoadClientsInvalidFiles(t *testing.T) {

--- a/fixtures/configs/test-config.yaml
+++ b/fixtures/configs/test-config.yaml
@@ -12,3 +12,5 @@ passwd_file : 'fixtures/ownership/passwd'
 group_file: 'fixtures/ownership/group'
 api_port: 31738
 poll_interval: 60s
+min_backoff: 23ms
+max_backoff: 87ms

--- a/ownership_test.go
+++ b/ownership_test.go
@@ -64,10 +64,10 @@ func TestFallback(t *testing.T) {
 
 // Verify we return an error if a file is missing
 func TestFileMissing(t *testing.T) {
-	_, err := lookupUID("group1", "non-existant-file")
+	_, err := lookupUID("group1", "non-existent-file")
 	assert.Error(t, err)
 
-	_, err = lookupGID("group1", "non-existant-file")
+	_, err = lookupGID("group1", "non-existent-file")
 	assert.Error(t, err)
 }
 

--- a/syncer.go
+++ b/syncer.go
@@ -221,7 +221,7 @@ func (s *Syncer) LoadClients() error {
 // buildClient collects the configuration and builds a client.  Most of this code should probably be refactored ito NewClient
 func (s *Syncer) buildClient(name string, clientConfig ClientConfig, metricsHandle *sqmetrics.SquareMetrics) (*syncerEntry, error) {
 	clientLogger := s.logger.WithField("client", name)
-	client, err := NewClient(clientConfig.Cert, clientConfig.Key, s.config.CaFile, s.server, time.Minute, int(s.config.MaxRetries), clientLogger, metricsHandle)
+	client, err := NewClient(&clientConfig, s.config.CaFile, s.server, clientLogger, metricsHandle)
 	if err != nil {
 		return nil, err
 	}

--- a/syncer.go
+++ b/syncer.go
@@ -221,7 +221,7 @@ func (s *Syncer) LoadClients() error {
 // buildClient collects the configuration and builds a client.  Most of this code should probably be refactored ito NewClient
 func (s *Syncer) buildClient(name string, clientConfig ClientConfig, metricsHandle *sqmetrics.SquareMetrics) (*syncerEntry, error) {
 	clientLogger := s.logger.WithField("client", name)
-	client, err := NewClient(clientConfig.Cert, clientConfig.Key, s.config.CaFile, s.server, time.Minute, clientLogger, metricsHandle)
+	client, err := NewClient(clientConfig.Cert, clientConfig.Key, s.config.CaFile, s.server, time.Minute, int(s.config.MaxRetries), clientLogger, metricsHandle)
 	if err != nil {
 		return nil, err
 	}

--- a/syncer_test.go
+++ b/syncer_test.go
@@ -71,14 +71,26 @@ func TestSyncerBuildClient(t *testing.T) {
 	assert.Equal(t, entry.ClientConfig, client1)
 
 	// Test misconfigured clients
-	entry, err = syncer.buildClient("missingkey", ClientConfig{DirName: "missingkey", Cert: "fixtures/clients/client4.crt"}, metricsForTest())
+	cfg := defaultClientConfig()
+	cfg.DirName = "missingkey"
+	cfg.Cert = "fixtures/clients/client4.crt"
+	cfg.Key = ""
+	entry, err = syncer.buildClient("missingkey", *cfg, metricsForTest())
 	require.NotNil(t, err)
 
-	entry, err = syncer.buildClient("missingcert", ClientConfig{DirName: "missingcert", Key: "fixtures/clients/client4.key"}, metricsForTest())
+	cfg = defaultClientConfig()
+	cfg.DirName = "missingcert"
+	cfg.Cert = ""
+	cfg.Key = "fixtures/clients/client4.key"
+	entry, err = syncer.buildClient("missingcert", *cfg, metricsForTest())
 	require.NotNil(t, err)
 
 	// The syncer currently handles clients configured with missing mountpoints
-	entry, err = syncer.buildClient("missingcert", ClientConfig{Key: "fixtures/clients/client4.key", Cert: "fixtures/clients/client4.crt"}, metricsForTest())
+	cfg = defaultClientConfig()
+	cfg.DirName = "valid"
+	cfg.Cert = "fixtures/clients/client4.crt"
+	cfg.Key = "fixtures/clients/client4.key"
+	entry, err = syncer.buildClient("missingcert", *cfg, metricsForTest())
 	require.Nil(t, err)
 }
 

--- a/vendor/github.com/jpillora/backoff/LICENSE
+++ b/vendor/github.com/jpillora/backoff/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Jaime Pillora
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/jpillora/backoff/backoff.go
+++ b/vendor/github.com/jpillora/backoff/backoff.go
@@ -1,0 +1,88 @@
+// Package backoff provides an exponential-backoff implementation.
+package backoff
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+// Backoff is a time.Duration counter, starting at Min. After every call to
+// the Duration method the current timing is multiplied by Factor, but it
+// never exceeds Max.
+//
+// Backoff is not generally concurrent-safe, but the ForAttempt method can
+// be used concurrently.
+type Backoff struct {
+	//Factor is the multiplying factor for each increment step
+	attempt, Factor float64
+	//Jitter eases contention by randomizing backoff steps
+	Jitter bool
+	//Min and Max are the minimum and maximum values of the counter
+	Min, Max time.Duration
+}
+
+// Duration returns the duration for the current attempt before incrementing
+// the attempt counter. See ForAttempt.
+func (b *Backoff) Duration() time.Duration {
+	d := b.ForAttempt(b.attempt)
+	b.attempt++
+	return d
+}
+
+const maxInt64 = float64(math.MaxInt64 - 512)
+
+// ForAttempt returns the duration for a specific attempt. This is useful if
+// you have a large number of independent Backoffs, but don't want use
+// unnecessary memory storing the Backoff parameters per Backoff. The first
+// attempt should be 0.
+//
+// ForAttempt is concurrent-safe.
+func (b *Backoff) ForAttempt(attempt float64) time.Duration {
+	// Zero-values are nonsensical, so we use
+	// them to apply defaults
+	min := b.Min
+	if min <= 0 {
+		min = 100 * time.Millisecond
+	}
+	max := b.Max
+	if max <= 0 {
+		max = 10 * time.Second
+	}
+	if min >= max {
+		// short-circuit
+		return max
+	}
+	factor := b.Factor
+	if factor <= 0 {
+		factor = 2
+	}
+	//calculate this duration
+	minf := float64(min)
+	durf := minf * math.Pow(factor, attempt)
+	if b.Jitter {
+		durf = rand.Float64()*(durf-minf) + minf
+	}
+	//ensure float64 wont overflow int64
+	if durf > maxInt64 {
+		return max
+	}
+	dur := time.Duration(durf)
+	//keep within bounds
+	if dur < min {
+		return min
+	} else if dur > max {
+		return max
+	}
+	return dur
+}
+
+// Reset restarts the current attempt counter at zero.
+func (b *Backoff) Reset() {
+	b.attempt = 0
+}
+
+// Attempt returns the current attempt counter value.
+func (b *Backoff) Attempt() float64 {
+	return b.attempt
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -66,6 +66,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/jpillora/backoff",
+			"repository": "https://github.com/jpillora/backoff",
+			"vcs": "git",
+			"revision": "8eab2debe79d12b7bd3d10653910df25fa9552ba",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/pkg/errors",
 			"repository": "https://github.com/pkg/errors",
 			"vcs": "git",


### PR DESCRIPTION
This PR should address issues discussed in #30.

**TL;DR: This PR introduces retries with exponential backoff (+ jitter for spreading the load) for each client sync API call**

Thoughts/questions:
- I was on the fence where the retry should happen (in syncer or client), but went with the client to keep the complexity hidden.
- Currently, we ignore fail counts as long as a retry succeeded. We might care at some point to see how often we have to retry to succeed, but seemed like unnecessary noise at this point.
- ~~I'm still pondering the best config representation for the backoff, and I'm leaning towards using strings and `time.ParseDuration`. I've added some simple validation checks for the config, so would be easy to get this changed and handle potential errors.~~ `Timeout`, `MinBackoff` and `MaxBackoff` can now be specified in the same way as `PollInterval` (so `20s`, `100ms` etc.)
- I've relied on a simple 3rd party lib for backoff (that I have used before). It's MIT licensed, so ~~hopefully~~ that's OK.

