### PR TITLE
Check that secret's filename override is not a filepath

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	pkgerr "github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
 	"github.com/square/go-sq-metrics"
 )
@@ -238,7 +239,10 @@ func (c KeywhizHTTPClient) SecretList() (map[string]Secret, error) {
 	}
 	secrets := map[string]Secret{}
 	for _, secret := range secretList {
-		filename := secret.Filename()
+		filename, err := secret.Filename()
+		if err != nil {
+			return nil, pkgerr.Wrap(err, "unable to get secret's filename")
+		}
 		if duplicate, ok := secrets[filename]; ok {
 			// This is not supported by Keysync. This stops syncing until the data inconsistency is fixed in the server.
 			return nil, fmt.Errorf("Duplicate filename detected: %s on secrets %s and %s",

--- a/fixtures/secretsWithBadFilenameOverride.json
+++ b/fixtures/secretsWithBadFilenameOverride.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name" : "Nobody_PgPass",
+    "secret" : "YXNkZGFz",
+    "secretLength" : 6,
+    "creationDate" : "2011-09-29T15:46:00.232Z",
+    "isVersioned" : false,
+    "mode" : "0400",
+    "owner" : "nobody",
+    "filename": "../../bla"
+  }
+]

--- a/secret_test.go
+++ b/secret_test.go
@@ -119,3 +119,27 @@ func TestContentErrors(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.EqualValues(t, originalContent, s.Content)
 }
+
+func TestFilename(t *testing.T) {
+	filenameOverride := "../../deleteme"
+	s := Secret{Name: "mydbsecret", FilenameOverride: &filenameOverride}
+	name, err := s.Filename()
+	require.NotNil(t, err)
+	require.Empty(t, name)
+
+	s = Secret{Name: "../../mydbsecret"}
+	name, err = s.Filename()
+	require.NotNil(t, err)
+	require.Empty(t, name)
+
+	s = Secret{Name: "mydbsecret"}
+	name, err = s.Filename()
+	require.Nil(t, err)
+	require.Equal(t, "mydbsecret", name)
+
+	filenameOverride = "fileoverride"
+	s = Secret{Name: "mydbsecret", FilenameOverride: &filenameOverride}
+	name, err = s.Filename()
+	require.Nil(t, err)
+	require.Equal(t, "fileoverride", name)
+}

--- a/syncer.go
+++ b/syncer.go
@@ -341,9 +341,8 @@ func (entry *syncerEntry) Sync() error {
 		}
 		state, err := entry.output.Write(secret)
 		// TODO: Filename changes of secrets might be noisy.  We should ensure they're handled more gracefully.
-		filename = secret.Filename()
 		if err != nil {
-			entry.Logger().WithError(err).WithField("secret", filename).Error("Failed while writing secret")
+			entry.Logger().WithError(err).WithField("secret", secret.Name).Error("Failed while writing secret")
 			// This situation is unlikely: We couldn't write the secret to disk.
 			// If Output.Write fails, then no changes to the secret on-disk were made, thus we make no change
 			// to the entry.SyncState

--- a/write_test.go
+++ b/write_test.go
@@ -163,3 +163,17 @@ func TestCustomFilename(t *testing.T) {
 
 	assert.False(t, out.Validate(&secret, *state), "Expected secret to be removed")
 }
+
+// TestCustomFilenameAsFilepath makes sure we fail to write a file if the "filename" is actually a filepath
+func TestCustomFilenameAsFilepath(t *testing.T) {
+	c, _, _, out := testFixture(t)
+	defer os.RemoveAll(c.SecretsDir)
+
+	secret := testSecret("secret_name")
+	filename := "../override_filename"
+	secret.FilenameOverride = &filename
+
+	state, err := out.Write(&secret)
+	assert.Error(t, err)
+	assert.Nil(t, state)
+}


### PR DESCRIPTION
Keysync assumes that any Keywhiz 404 response to a GET /secret means
that a secret has been deleted and it attempts to delete that secret
from a local filesystem. The operational assumption is that a secret
name's cannot be a filepath. Keysync properly checks for that before
writing a file to disk, but not before attempting to delete a stale
secret. This opens up Keysync to a vulnerability that would potentially
allow to delete any file on the system. This change addresses the issue.