### PR TITLE
Allow a seperate CA bundle for Sentry

### DIFF
--- a/cmd/keysync/keysync.go
+++ b/cmd/keysync/keysync.go
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This is the main entry point for Keysync.  It assumes a bit more about the environment you're using keysync in than
-// the keysync library.  In particular, you may want to have your own version of this for a different monitoring system
-// than Sentry, a different configuration or command line format, or any other customization you need.
+// This is the main entry point for Keysync.  It assumes a bit more about the
+// environment you're using keysync in than the keysync library.  In
+// particular, you may want to have your own version of this for a different
+// monitoring system than Sentry, a different configuration or command line
+// format, or any other customization you need.
 package main
 
 import (
@@ -72,7 +74,7 @@ func main() {
 	}
 
 	if config.SentryDSN != "" {
-		hook, err := configureLogrusSentry(config.SentryDSN, config.CaFile)
+		hook, err := configureLogrusSentry(config.SentryDSN, config.SentryCaFile)
 
 		if err == nil {
 			log.Hooks.Add(hook)

--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ import (
 type Config struct {
 	ClientsDir    string     `yaml:"client_directory"`  // A directory of configuration files
 	SecretsDir    string     `yaml:"secrets_directory"` // The directory secrets will be written to
-	CaFile        string     `yaml:"ca_file"`           // The CA to trust (PEM)
+	CaFile        string     `yaml:"ca_file"`           // The CA to trust (PEM) for Keywhiz communication
 	YamlExt       string     `yaml:"yaml_ext"`          // The filename extension of the yaml config files
 	PollInterval  string     `yaml:"poll_interval"`     // If specified, poll at the given interval, otherwise, exit after syncing
 	ClientTimeout string     `yaml:"client_timeout"`    // If specified, timeout client connections after specified duration, otherwise use default.
@@ -43,6 +43,7 @@ type Config struct {
 	GroupFile     string     `yaml:"group_file"`        // /etc/groups, for gid lookups
 	APIPort       uint16     `yaml:"api_port"`          // Port for API to listen on
 	SentryDSN     string     `yaml:"sentry_dsn"`        // Sentry DSN
+	SentryCaFile  string     `yaml:"sentry_ca_file"`    // The CA to trust (PEM) for Sentry communication
 	FsType        Filesystem `yaml:"filesystem_type"`   // Enforce writing this type of filesystem. Use value from statfs.
 	ChownFiles    bool       `yaml:"chown_files"`       // Do we chown files? Set to false when running without CAP_CHOWN.
 	MetricsPrefix string     `yaml:"metrics_prefix"`    // Prefix metric names with this


### PR DESCRIPTION
This allows using an internal PKI for Keywhiz, and an external truststore for
Sentry, for example if you're using Sentry.io or otherwise hosting Sentry
externally.