### PR TITLE
Make cert lifetime warnings more verbose

### DIFF
--- a/monitor/checks.go
+++ b/monitor/checks.go
@@ -76,11 +76,15 @@ func checkCertificate(name string, client *keysync.ClientConfig, minCertLifetime
 
 	leaf, err := x509.ParseCertificate(keyPair.Certificate[0])
 	if err != nil {
-		return fmt.Errorf("invalid key/cert in config for client %s: %s", name, err)
+		return fmt.Errorf("invalid client certificate for client %s: %s", name, err)
+	}
+
+	if leaf.NotAfter.Before(time.Now()) {
+		return fmt.Errorf("expired client certificate for client %s: NotAfter %s", name, leaf.NotAfter.Format(time.RFC3339))
 	}
 
 	if expiryThreshold := time.Now().Add(minCertLifetime); leaf.NotAfter.Before(expiryThreshold) {
-		return fmt.Errorf("expired/expiring key/cert in config for client %s", name)
+		return fmt.Errorf("expiring client certificate for client %s: NotAfter %s is within %s of now", name, leaf.NotAfter.Format(time.RFC3339), minCertLifetime)
 	}
 
 	return nil

--- a/monitor/checks_test.go
+++ b/monitor/checks_test.go
@@ -81,7 +81,7 @@ func assertError(t *testing.T, errs []error, expected string) {
 		}
 	}
 
-	t.Fatalf("expected error '%s', but was not in error list", expected)
+	t.Fatalf("expected error '%s', but was not in error list: %q", expected, errs)
 }
 
 func TestCheckClientHealth(t *testing.T) {
@@ -94,5 +94,5 @@ func TestCheckClientHealth(t *testing.T) {
 	assertError(t, errs, "client appears to have zero secrets")
 
 	// Min lifetime is set to be ten years, so the cert should alert.
-	assertError(t, errs, "expired/expiring key/cert in config for client")
+	assertError(t, errs, "expiring client certificate")
 }


### PR DESCRIPTION
This makes it easier to distinguish expired from expiring, and to figure out
the appropriate level of urgency from the alert alone.