### PR TITLE
Delete secrets when syncing a removed client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ install:
 
 script:
  - go test -v ./...
- - docker run -it keysync-test
+ - docker run -it --rm keysync-test

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre-alpine
 
-RUN apk add --update bash go gcc git musl-dev diffutils util-linux coreutils && \
+RUN apk add --update bash go gcc git musl-dev diffutils util-linux coreutils curl && \
     rm -rf /var/cache/apk/*
 
 COPY testing /opt/keysync/testing/

--- a/api_test.go
+++ b/api_test.go
@@ -134,7 +134,7 @@ func TestApiSyncOneError(t *testing.T) {
 	syncer, err := NewSyncer(config, OutputDirCollection{}, logrus.NewEntry(logrus.New()), metricsForTest())
 	require.Nil(t, err)
 
-	err = syncer.LoadClients()
+	_, err = syncer.LoadClients()
 	assert.NotNil(t, err)
 
 	NewAPIServer(syncer, port, logrus.NewEntry(logrus.New()), metricsForTest())
@@ -170,7 +170,7 @@ func TestHealthCheck(t *testing.T) {
 	syncer, err := NewSyncer(config, OutputDirCollection{}, logrus.NewEntry(logrus.New()), metricsForTest())
 	require.Nil(t, err)
 
-	err = syncer.LoadClients()
+	_, err = syncer.LoadClients()
 	assert.NotNil(t, err)
 
 	NewAPIServer(syncer, port, logrus.NewEntry(logrus.New()), metricsForTest())
@@ -208,7 +208,7 @@ func TestMetricsReporting(t *testing.T) {
 	syncer, err := NewSyncer(config, OutputDirCollection{}, logrus.NewEntry(logrus.New()), metricsForTest())
 	require.Nil(t, err)
 
-	err = syncer.LoadClients()
+	_, err = syncer.LoadClients()
 	assert.NotNil(t, err)
 
 	NewAPIServer(syncer, port, logrus.NewEntry(logrus.New()), metricsForTest())

--- a/syncer_test.go
+++ b/syncer_test.go
@@ -34,11 +34,11 @@ func TestSyncerLoadClients(t *testing.T) {
 	syncer, err := NewSyncer(config, NewInMemoryOutputCollection(), logrus.NewEntry(logrus.New()), metricsForTest())
 	require.Nil(t, err)
 
-	err = syncer.LoadClients()
+	_, err = syncer.LoadClients()
 	require.Nil(t, err)
 
 	// The clients should reload without error
-	err = syncer.LoadClients()
+	_, err = syncer.LoadClients()
 	require.Nil(t, err)
 }
 
@@ -49,7 +49,7 @@ func TestSyncerLoadClientsError(t *testing.T) {
 	syncer, err := NewSyncer(config, NewInMemoryOutputCollection(), logrus.NewEntry(logrus.New()), metricsForTest())
 	require.Nil(t, err)
 
-	err = syncer.LoadClients()
+	_, err = syncer.LoadClients()
 	require.NotNil(t, err)
 }
 
@@ -156,7 +156,7 @@ func TestSyncerRunLoadClientsFails(t *testing.T) {
 }
 
 func TestNewSyncerFails(t *testing.T) {
-	// Load a test config which fails on LoadCLients
+	// Load a test config which fails on LoadClients
 	config, err := LoadConfig("fixtures/configs/errorconfigs/nonexistent-client-dir-config.yaml")
 	require.Nil(t, err)
 
@@ -176,7 +176,7 @@ func TestSyncerEntrySyncKeywhizFails(t *testing.T) {
 	syncer, err := createNewSyncer("fixtures/configs/test-config.yaml", server)
 	require.Nil(t, err)
 
-	err = syncer.LoadClients()
+	_, err = syncer.LoadClients()
 	require.Nil(t, err)
 
 	for name, entry := range syncer.clients {
@@ -209,7 +209,7 @@ func TestSyncerEntrySyncKeywhizFails(t *testing.T) {
 
 	// Clear and reload the clients to force them to pick up the new server
 	syncer.clients = make(map[string]syncerEntry)
-	err = syncer.LoadClients()
+	_, err = syncer.LoadClients()
 	require.Nil(t, err)
 
 	for name, entry := range syncer.clients {
@@ -242,7 +242,7 @@ func TestSyncerEntrySyncKeywhizFails(t *testing.T) {
 
 	// Clear and reload the clients to force them to pick up the new server
 	syncer.clients = make(map[string]syncerEntry)
-	err = syncer.LoadClients()
+	_, err = syncer.LoadClients()
 	require.Nil(t, err)
 
 	for name, entry := range syncer.clients {
@@ -273,7 +273,7 @@ func TestSyncerEntrySyncKeywhizFails(t *testing.T) {
 
 	// Clear and reload the clients to force them to pick up the new server
 	syncer.clients = make(map[string]syncerEntry)
-	err = syncer.LoadClients()
+	_, err = syncer.LoadClients()
 	require.Nil(t, err)
 
 	for _, entry := range syncer.clients {

--- a/testing/run-tests.sh
+++ b/testing/run-tests.sh
@@ -2,6 +2,7 @@
 
 set -eu
 set -o pipefail
+set -x
 
 # Start keywhiz (server)
 java -jar /opt/keysync/testing/keywhiz-server.jar server /opt/keysync/testing/keywhiz-config.yaml &
@@ -9,25 +10,55 @@ java -jar /opt/keysync/testing/keywhiz-server.jar server /opt/keysync/testing/ke
 # Start keysync (client)
 keysync --config /opt/keysync/testing/keysync-config.yaml &
 
-# Some time to finish sync
-# TODO(cs): use curl and hit status endpoint when openjdk/alpine image updates curl package
-sleep 20
+# Call the /sync endpoint which blocks until synced
+sleep 5
+curl --retry 20 -X POST http://localhost:31738/sync
 
 # Diff content & permissions
-cd /secrets/client1
+function verify {
+  pushd $1
+  for file in *; do
+    perms_actual="$(stat -c '%U:%G:%a' "$file")"
+    perms_expected="$(cat /opt/keysync/testing/expected/ownership/"$file")"
+    content_actual="$(cat "$file")"
+    content_expected="$(cat /opt/keysync/testing/expected/content/"$file")"
 
-for file in *; do
-  perms_actual="$(stat -c '%U:%G:%a' "$file")"
-  perms_expected="$(cat /opt/keysync/testing/expected/ownership/"$file")"
-  content_actual="$(cat "$file")"
-  content_expected="$(cat /opt/keysync/testing/expected/content/"$file")"
+    if [ "$perms_actual" != "$perms_expected" ]; then
+      echo "ERROR: Incorrect ownership on file $file (expecting $perms_expected, got $perms_actual)"
+      exit 1
+    fi
+    if [ "$content_actual" != "$content_expected" ]; then
+      echo "ERROR: Incorrect content in file $file (expecting $content_expected, got $content_actual)"
+      exit 1
+    fi
+  done
+  echo "Verified $1"
+  popd
+}
 
-  if [ "$perms_actual" != "$perms_expected" ]; then
-    echo "ERROR: Incorrect ownership on file $file (expecting $perms_expected, got $perms_actual)"
-    exit 1
-  fi
-  if [ "$content_actual" != "$content_expected" ]; then
-    echo "ERROR: Incorrect content in file $file (expecting $content_expected, got $content_actual)"
-    exit 1
-  fi
-done
+verify /secrets/client1
+
+# Make a second client
+sed 's/client1/client2/g' /opt/keysync/testing/clients/client.yaml > /opt/keysync/testing/clients/client2.yaml
+
+curl --fail -X POST http://localhost:31738/sync/client2
+
+verify /secrets/client2
+
+rm /opt/keysync/testing/clients/client2.yaml
+
+curl --fail -X POST http://localhost:31738/sync/client2
+
+if [ -d /secrets/client2 ]; then
+  echo "ERROR: Client 2 was not removed"
+  exit 1
+fi
+
+# Subsequent try should 404
+curl -X POST http://localhost:31738/sync/client2
+
+# Make sure client 1 still works
+curl --fail -X POST http://localhost:31738/sync/client1
+verify /secrets/client1
+
+echo "Test passed"


### PR DESCRIPTION
Previously, we'd wait until the next full sync, which was a bit confusing, and
a bit hard to test.

This removes the somewhat awkward "oldClients" state from the Syncer and just
returns the clients that need to be cleaned up.  That simplifies the RunOnce
function, which was a bit big too.

Extends the integration test to check client deletion works.