### PR TITLE
Implement Keysync Backup/Restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 fixtures/clients/client[1-4]
 testing/secrets
-keysync
-keyrestore
+/keysync
+/cmd/keysync/keysync
+/keyrestore
+/cmd/keyrestore/keyrestore

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -19,8 +19,9 @@ RUN go mod download
 COPY . /opt/keysync
 
 WORKDIR /opt/keysync/cmd/keysync
-
 RUN go build -o /usr/bin/keysync
 
+WORKDIR /opt/keysync/cmd/keyrestore
+RUN go build -o /usr/bin/keyrestore
 
 CMD /opt/keysync/testing/run-tests.sh

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -1,0 +1,91 @@
+// package backup handles reading and writing encrypted .tar files from the secretsDirectory to
+// a backupPath using the key backupKey.
+package backup
+
+import (
+	"encoding/hex"
+	"io/ioutil"
+
+	"github.com/square/keysync/output"
+
+	"github.com/pkg/errors"
+)
+
+type Backup interface {
+	Backup() error
+	Restore() error
+}
+
+type FileBackup struct {
+	SecretsDirectory string
+	BackupPath       string
+	KeyPath          string
+	Chown            bool
+	EnforceFS        output.Filesystem
+}
+
+// Backup is intended to be implemented by FileBackup
+var _ Backup = &FileBackup{}
+
+func (b *FileBackup) loadKey() ([]byte, error) {
+	keyhex, err := ioutil.ReadFile(b.KeyPath)
+	if err != nil {
+		return nil, err
+	}
+	key := make([]byte, hex.DecodedLen(len(keyhex)))
+	if _, err := hex.Decode(key, keyhex); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// Backup loads all files in b.SecretsDirectory, tars, compresses, then encrypts with b.BackupKey
+// The content is written to b.BackupPath
+func (b *FileBackup) Backup() error {
+	tarball, err := createTar(b.SecretsDirectory)
+	if err != nil {
+		return err
+	}
+
+	key, err := b.loadKey()
+	if err != nil {
+		return err
+	}
+
+	// Encrypt it
+	encrypted, err := encrypt(tarball, key)
+	if err != nil {
+		return errors.Wrap(err, "error encrypting backup")
+	}
+
+	// We always write as r-- --- ---, aka 0400
+	// UID/GID in this struct are ignored as chownFiles: false
+	perms := output.FileInfo{Mode: 0400}
+	// Write it out, and if it errored, wrapped the error
+	_, err = output.WriteFileAtomically(b.BackupPath, false, perms, 0, encrypted)
+	return err
+}
+
+// Restore opens b.BackupPath, decrypts with b.BackupKey, and writes contents to b.SecretsDirectory
+func (b *FileBackup) Restore() error {
+	ciphertext, err := ioutil.ReadFile(b.BackupPath)
+	if err != nil {
+		return errors.Wrap(err, "error reading backup")
+	}
+
+	key, err := b.loadKey()
+	if err != nil {
+		return err
+	}
+
+	tarball, err := decrypt(ciphertext, key)
+	if err != nil {
+		return errors.Wrap(err, "error decrypting backup")
+	}
+
+	if err := extractTar(tarball, b.Chown, b.SecretsDirectory, b.EnforceFS); err != nil {
+		return errors.Wrap(err, "Error extracting tarball")
+	}
+
+	return nil
+}

--- a/backup/crypto.go
+++ b/backup/crypto.go
@@ -1,0 +1,45 @@
+package backup
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+func aesgcm(key []byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return cipher.NewGCM(block)
+}
+
+func encrypt(data, key []byte) ([]byte, error) {
+	aesgcm, err := aesgcm(key)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, aesgcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, errors.Wrap(err, "Error reading random for nonce")
+	}
+
+	// Seal appends to the first parameter, so we append ciphertext to the nonce
+	return aesgcm.Seal(nonce, nonce, data, nil), nil
+}
+
+func decrypt(data, key []byte) ([]byte, error) {
+	aesgcm, err := aesgcm(key)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := aesgcm.NonceSize()
+	// Nonce is prefixed to data
+	return aesgcm.Open(nil, data[:nonceSize], data[nonceSize:], nil)
+}

--- a/backup/crypto_test.go
+++ b/backup/crypto_test.go
@@ -1,0 +1,48 @@
+package backup
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEncryptDecrypt takes a random buffer, encrypts, then decrypts.
+func TestEncryptDecrypt(t *testing.T) {
+	// Make a random buffer of data to test with:
+	testData := make([]byte, 1234)
+	copyData := make([]byte, 1234)
+	_, err := io.ReadFull(rand.Reader, testData)
+	require.NoError(t, err)
+	copy(copyData, testData)
+
+	key := make([]byte, 16)
+	_, err = io.ReadFull(rand.Reader, key)
+	require.NoError(t, err)
+
+	ciphertext, err := encrypt(testData, key)
+	assert.NoError(t, err)
+
+	// from crypto/cipher/gcm.go
+	gcmStandardNonceSize := 12
+	gcmTagSize := 16
+
+	// The ciphertext should be longer than the plaintext
+	assert.Equal(t, len(testData)+gcmStandardNonceSize+gcmTagSize, len(ciphertext))
+
+	// We can't really make any other assertions about the ciphertext
+	// But make sure the ciphertext doesn't literally contain the plaintext
+	assert.False(t, bytes.Contains(ciphertext, copyData))
+
+	plaintext, err := decrypt(ciphertext, key)
+	assert.NoError(t, err)
+
+	// Verify the plaintext roundtripped
+	assert.Equal(t, copyData, plaintext)
+
+	// Verify the testData wasn't modified during encryption
+	assert.Equal(t, copyData, testData)
+}

--- a/backup/tar.go
+++ b/backup/tar.go
@@ -1,0 +1,149 @@
+package backup
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/square/keysync/output"
+
+	"github.com/pkg/errors"
+)
+
+// Given a path to a directory, create and return a tarball of its content.
+// Careful, as this will pull the full contents into memory.
+// This is not a general-purpose function, but is intended to only work with Keysync
+// directories, which contain only non-executable regular files.
+func createTar(dir string) ([]byte, error) {
+	var tarball bytes.Buffer
+	tw := tar.NewWriter(&tarball)
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() || !info.Mode().IsRegular() {
+			// Skip directories and non-regular files.
+			return nil
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close() // We explicitly call close below with error handling, but this extra one handles early returns
+
+		// 2nd Argument to FileInfoHeader is only used for symlinks, which aren't relevant here
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+
+		// Set the name to be relative to the base directory
+		header.Name, err = filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+
+		if _, err := io.Copy(tw, f); err != nil {
+			return err
+		}
+
+		if err := f.Close(); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Tar writing adds a trailer in Close(), and can possibly return errors, so we need to check
+	// errors here.  We could also defer tw.Close(), but there's nothing to leak in the Tar Writer
+	// other than the io.Writer that's passed in.  That's the tarball buffer in this function, so
+	// we don't need to worry about leaking FDs. Calling Close() a 2nd time is always an error, so
+	// I think it makes the error handling trickier if we both explicitly and defer a call to Close.
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	return tarball.Bytes(), nil
+}
+
+// Given a tarball, write it out to dir, which must be empty or not exist
+// If Chown is true, set file ownership from the tarball.
+// This is intended to be only used with files from createTar.
+func extractTar(tarball []byte, chown bool, dirpath string, filesystem output.Filesystem) error {
+	// Open the destination directory and verify it's empty
+	dir, err := os.Open(dirpath)
+	if os.IsNotExist(err) {
+		// The directory doesn't exist, so try to make it.
+		if err := os.MkdirAll(dirpath, 0755); err != nil {
+			return errors.Wrapf(err, "could not create secrets directory %s", dirpath)
+		}
+		dir, err = os.Open(dirpath)
+	}
+	if err != nil {
+		return errors.Wrapf(err, "error opening secrets directory %s", dirpath)
+	}
+
+	info, err := dir.Stat()
+	if err != nil {
+		return errors.Wrapf(err, "could not stat directory %s", dirpath)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("secrets directory exists but is a file %s", dirpath)
+	}
+
+	// Check if the directory is empty
+	if list, err := dir.Readdir(-1); err != nil {
+		return errors.Wrapf(err, "could not read contents of secrets directory %s", dirpath)
+	} else if len(list) != 0 {
+		return fmt.Errorf("secrets directory exists but is nonempty (%d entries)", len(list))
+	}
+
+	// At this point, the directory exists and is non-empty, so let's unpack files there
+	tr := tar.NewReader(bytes.NewReader(tarball))
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return errors.Wrap(err, "error reading tar header")
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			// We don't need to care about directories, because they're created by WriteFileAtomically
+		case tar.TypeReg:
+			fileInfo := output.FileInfo{Mode: os.FileMode(header.Mode), UID: header.Uid, GID: header.Gid}
+
+			content, err := ioutil.ReadAll(tr)
+			if err != nil {
+				return errors.Wrapf(err, "error reading %s", header.Name)
+			}
+
+			if header.Name != filepath.Clean(header.Name) {
+				return fmt.Errorf("non-canonical file path in archive: %s", header.Name)
+			}
+			path := filepath.Join(dirpath, header.Name)
+
+			if _, err := output.WriteFileAtomically(path, chown, fileInfo, filesystem, content); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unhandled file %s of type %v", header.Name, header.Typeflag)
+		}
+	}
+
+	return nil
+}

--- a/backup/tar_test.go
+++ b/backup/tar_test.go
@@ -1,0 +1,62 @@
+package backup
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testSha(t *testing.T, hash string, file *os.File) {
+	sha := sha256.New()
+	_, err := io.Copy(sha, file)
+	assert.NoError(t, err)
+	assert.Equal(t, hash, hex.EncodeToString(sha.Sum(nil)))
+}
+
+// TestCreateExtractTar makes a tar of the testdata/ folder, then extracts it to a temp directory
+// and validates files and permissions are present as expected.
+func TestCreateExtractTar(t *testing.T) {
+	var testfiles = []struct {
+		path     string
+		perm     os.FileMode
+		sha2hash string
+	}{
+		{"alice.txt", 0440, "7708cf9d3d58e7a4e621ec2aa9fd47c678fd4a3411c804df060c041ee6237e4d"},
+		{"bob/bob.txt", 0404, "a802f68d223a903e282e310251585f26b1abdfe067854252d0f1bf33d334f768"},
+	}
+
+	// Ensure the test files have expected permissions and content beforehand
+	for _, test := range testfiles {
+		file, err := os.Open(filepath.Join("testdata", test.path))
+		require.NoError(t, err)
+		testSha(t, test.sha2hash, file)
+		require.NoError(t, file.Chmod(test.perm))
+	}
+
+	tar, err := createTar("testdata")
+	require.NoError(t, err)
+
+	tmpdir, err := ioutil.TempDir("", "test-create-extract-tar")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	err = extractTar(tar, false, tmpdir, 0)
+	require.NoError(t, err)
+
+	for _, test := range testfiles {
+		file, err := os.Open(filepath.Join(tmpdir, test.path))
+		assert.NoError(t, err)
+		info, err := file.Stat()
+		assert.NoError(t, err)
+		assert.EqualValues(t, test.perm, info.Mode().Perm(), "unexpected permissions on %s: %s", test.path, info.Mode().String())
+
+		testSha(t, test.sha2hash, file)
+	}
+}

--- a/backup/testdata/alice.txt
+++ b/backup/testdata/alice.txt
@@ -1,0 +1,3 @@
+Alice is a fictional character, commonly used as a placeholder name in Cryptography.
+
+This file is used in tests.

--- a/backup/testdata/bob/bob.txt
+++ b/backup/testdata/bob/bob.txt
@@ -1,0 +1,3 @@
+Bob is a fictional character, commonly used as a placeholder name in Cryptography.
+
+This file is used in tests.

--- a/client_test.go
+++ b/client_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	"github.com/square/go-sq-metrics"
+	sqmetrics "github.com/square/go-sq-metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/keysync/keysync.go
+++ b/cmd/keysync/keysync.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/square/keysync"
+	"github.com/square/keysync/backup"
 
 	"github.com/evalphobia/logrus_sentry"
 	"github.com/getsentry/raven-go"
@@ -92,9 +93,20 @@ func main() {
 			logger.WithError(err).Fatal("Failed while creating syncer")
 		}
 
+		var fileBackup backup.Backup = nil
+		if config.BackupPath != "" && config.BackupKeyPath != "" {
+			fileBackup = &backup.FileBackup{
+				SecretsDirectory: config.SecretsDir,
+				BackupPath:       config.BackupPath,
+				KeyPath:          config.BackupKeyPath,
+				Chown:            config.ChownFiles,
+				EnforceFS:        config.FsType,
+			}
+		}
+
 		// Start the API server
 		if config.APIPort != 0 {
-			keysync.NewAPIServer(syncer, config.APIPort, logger, metricsHandle)
+			keysync.NewAPIServer(syncer, fileBackup, config.APIPort, logger, metricsHandle)
 		}
 
 		logger.Info("Starting syncer")

--- a/config.go
+++ b/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	ChownFiles    bool              `yaml:"chown_files"`       // Do we chown files? Set to false when running without CAP_CHOWN.
 	MetricsPrefix string            `yaml:"metrics_prefix"`    // Prefix metric names with this
 	Monitor       MonitorConfig     `yaml:"monitor"`           // Config for monitoring/alerts
+	BackupPath    string            `yaml:"backup_path"`       // If specified, back up secrets as an encrypted tarball to this location
+	BackupKeyPath string            `yaml:"backup_key_path"`   // If specified, read a hex-encoded AES key from this path for backups
 }
 
 // The MonitorConfig has extra settings for monitoring/alerts.
@@ -87,6 +89,15 @@ func LoadConfig(configFile string) (*Config, error) {
 
 	if config.SecretsDir == "" {
 		return nil, fmt.Errorf("mandatory config secrets_directory not provided: %s", configFile)
+	}
+
+	// Must specify both or neither of BackupKeyPath and BackupPath
+	if config.BackupKeyPath != "" && config.BackupPath == "" {
+		return nil, fmt.Errorf("backup_key_path specified (%s) without backup_path", config.BackupKeyPath)
+	}
+
+	if config.BackupKeyPath == "" && config.BackupPath != "" {
+		return nil, fmt.Errorf("backup_key specified (%s) without backup_key_path", config.BackupPath)
 	}
 
 	if config.MaxRetries < 1 {

--- a/syncer_test.go
+++ b/syncer_test.go
@@ -180,7 +180,7 @@ func TestSyncerEntrySyncKeywhizFails(t *testing.T) {
 	require.Nil(t, err)
 
 	for name, entry := range syncer.clients {
-		err = entry.Sync()
+		_, err = entry.Sync()
 		require.Nil(t, err, "No error expected updating entry %s", name)
 
 		// Check the files in the mountpoint
@@ -213,7 +213,7 @@ func TestSyncerEntrySyncKeywhizFails(t *testing.T) {
 	require.Nil(t, err)
 
 	for name, entry := range syncer.clients {
-		err = entry.Sync()
+		_, err = entry.Sync()
 		require.Nil(t, err, "No error expected updating entry %s", name)
 
 		// Check the files in the mountpoint
@@ -246,7 +246,7 @@ func TestSyncerEntrySyncKeywhizFails(t *testing.T) {
 	require.Nil(t, err)
 
 	for name, entry := range syncer.clients {
-		err = entry.Sync()
+		_, err = entry.Sync()
 		require.Nil(t, err, "No error expected updating entry %s", name)
 
 		// Check the files in the mountpoint
@@ -277,7 +277,7 @@ func TestSyncerEntrySyncKeywhizFails(t *testing.T) {
 	require.Nil(t, err)
 
 	for _, entry := range syncer.clients {
-		err = entry.Sync()
+		_, err = entry.Sync()
 		require.NotNil(t, err)
 
 		// Check the files in the mountpoint

--- a/testing/keysync-config.yaml
+++ b/testing/keysync-config.yaml
@@ -10,3 +10,5 @@ default_user: 'keysync-test'
 default_group: 'keysync-test'
 api_port: 31738
 poll_interval: 1s
+backup_key_path: /tmp/keysync-backup.key
+backup_path: /tmp/keysync-backup.tar.enc

--- a/testing/run-tests.sh
+++ b/testing/run-tests.sh
@@ -4,11 +4,16 @@ set -eu
 set -o pipefail
 set -x
 
+# Backup key for keysync, generated with `openssl rand -hex 16`
+echo -n dd080878dbff297b06036bcc25f775f2 > /tmp/keysync-backup.key
+
 # Start keywhiz (server)
 java -jar /opt/keysync/testing/keywhiz-server.jar server /opt/keysync/testing/keywhiz-config.yaml &
+keywhiz_pid=$!
 
 # Start keysync (client)
 keysync --config /opt/keysync/testing/keysync-config.yaml &
+keysync_pid=$!
 
 # Call the /sync endpoint which blocks until synced
 sleep 5
@@ -16,7 +21,7 @@ curl --retry 20 -X POST http://localhost:31738/sync
 
 # Diff content & permissions
 function verify {
-  pushd $1
+  pushd "$1"
   for file in *; do
     perms_actual="$(stat -c '%U:%G:%a' "$file")"
     perms_expected="$(cat /opt/keysync/testing/expected/ownership/"$file")"
@@ -45,6 +50,9 @@ curl --fail -X POST http://localhost:31738/sync/client2
 
 verify /secrets/client2
 
+# Create a backup
+curl --fail -X POST http://localhost:31738/backup
+
 rm /opt/keysync/testing/clients/client2.yaml
 
 curl --fail -X POST http://localhost:31738/sync/client2
@@ -61,4 +69,26 @@ curl -X POST http://localhost:31738/sync/client2
 curl --fail -X POST http://localhost:31738/sync/client1
 verify /secrets/client1
 
-echo "Test passed"
+
+# Stop keysync & keywhiz
+kill $keywhiz_pid
+kill $keysync_pid
+
+sleep 1
+
+# Keysync should have written a backup to this location
+backup_file="/tmp/keysync-backup.tar.enc"
+if [[ ! -f "$backup_file"  ]]; then
+  echo "Backup file $backup_file is missing"
+fi
+
+rm -rf /secrets
+
+# Restore the backup
+keyrestore --config /opt/keysync/testing/keysync-config.yaml
+
+# Make sure both clients are present in backup.  Client 2 was removed after backup was run.
+verify /secrets/client1
+verify /secrets/client2
+
+echo "Keysync test passed"

--- a/util_test.go
+++ b/util_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/rcrowley/go-metrics"
 	"github.com/sirupsen/logrus"
-	"github.com/square/go-sq-metrics"
+	sqmetrics "github.com/square/go-sq-metrics"
 )
 
 // Create metrics for testing purposes
@@ -108,6 +108,8 @@ type InMemoryOutputCollection struct {
 	Outputs map[string]InMemoryOutput
 }
 
+var _ OutputCollection = InMemoryOutputCollection{}
+
 func NewInMemoryOutputCollection() InMemoryOutputCollection {
 	return InMemoryOutputCollection{Outputs: map[string]InMemoryOutput{}}
 }
@@ -125,8 +127,8 @@ func (c InMemoryOutputCollection) NewOutput(clientConfig ClientConfig, logger *l
 	return output, nil
 }
 
-func (c InMemoryOutputCollection) Cleanup(_ map[string]struct{}, _ *logrus.Entry) []error {
-	return nil
+func (c InMemoryOutputCollection) Cleanup(_ map[string]struct{}, _ *logrus.Entry) (uint, []error) {
+	return 0, nil
 }
 
 type InMemoryOutput struct {
@@ -156,14 +158,15 @@ func (out InMemoryOutput) Remove(name string) error {
 	return nil
 }
 
-func (out InMemoryOutput) RemoveAll() error {
+func (out InMemoryOutput) RemoveAll() (uint, error) {
+	deleted := uint(len(out.Secrets))
 	out.deletesCounter += len(out.Secrets)
 	out.Secrets = map[string]Secret{}
-	return nil
+	return deleted, nil
 }
 
-func (out InMemoryOutput) Cleanup(_ map[string]Secret) error {
-	return nil
+func (out InMemoryOutput) Cleanup(_ map[string]Secret) (uint, error) {
+	return 0, nil
 }
 
 func (out InMemoryOutput) Logger() *logrus.Entry {


### PR DESCRIPTION
This is a first pass at implementing an encrypted backup feature for keysync.
This writes an AES-GCM encrypted tar file to a configured disk location,
containing the secrets keysync has written out to the regular secrets location.

The Keyrestore program is updated to take these encrypted files and restore
them.

This is useful if you want to avoid writing plaintext secrets to disk, but want
a way to reboot or recover servers without Keywhiz running (eg, in an outage
scenario).

Right now a fixed AES key is used.  It is loaded after syncing completes, so
you can use a key stored in Keywhiz.  Recovering that key is left as an
exercise to the reader, or future improvements to this tool.