### PR TITLE
Add syncer uptime to the API and improve server health check

### DIFF
--- a/cmd/monitor/checks.go
+++ b/cmd/monitor/checks.go
@@ -123,7 +123,7 @@ func checkServerHealth(config *keysync.Config) []error {
 		return []error{fmt.Errorf("invalid JSON status response: %s", err)}
 	}
 
-	if !status.Ok {
+	if !status.Ok && status.SyncerUptime >= config.Monitor.MaxInitialSyncDuration {
 		return []error{fmt.Errorf("keysync unhealthy: %s", status.Message)}
 	}
 

--- a/config.go
+++ b/config.go
@@ -58,11 +58,12 @@ type Config struct {
 
 // The MonitorConfig has extra settings for monitoring/alerts.
 type MonitorConfig struct {
-	MinCertLifetime     time.Duration `yaml:"min_cert_lifetime"`     // If specified, warn if cert does not have given min lifetime.
-	MinSecretsCount     int           `yaml:"min_secrets_count"`     // If specified, warn if client has less than minimum number of secrets
-	AlertEmailServer    string        `yaml:"alert_email_server"`    // For alert emails: SMTP server host:port to use for sending email
-	AlertEmailRecipient string        `yaml:"alert_email_recipient"` // For alert emails: Recipient of alert emails
-	AlertEmailSender    string        `yaml:"alert_email_sender"`    // For alert emails: Sender (from) for alert emails
+	MinCertLifetime        time.Duration `yaml:"min_cert_lifetime"`         // If specified, warn if cert does not have given min lifetime.
+	MinSecretsCount        int           `yaml:"min_secrets_count"`         // If specified, warn if client has less than minimum number of secrets
+	MaxInitialSyncDuration time.Duration `yaml:"max_initial_sync_duration"` // If specified, warn if keysync has fully synced after a given interval
+	AlertEmailServer       string        `yaml:"alert_email_server"`        // For alert emails: SMTP server host:port to use for sending email
+	AlertEmailRecipient    string        `yaml:"alert_email_recipient"`     // For alert emails: Recipient of alert emails
+	AlertEmailSender       string        `yaml:"alert_email_sender"`        // For alert emails: Sender (from) for alert emails
 }
 
 // The ClientConfig describes a single Keywhiz client.  There are typically many of these per keysync instance.

--- a/go.mod
+++ b/go.mod
@@ -24,3 +24,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 )
+
+go 1.13


### PR DESCRIPTION
keymonitor will not alert on keysync health if the syncer uptime (now
returned as part of the `StatusResponse`) is lower than the configurable
`MaxInitialSyncDuration`.