### PR TITLE
Fix potential path traversal vulnerability in the restore flow

### DIFF
--- a/backup/tar.go
+++ b/backup/tar.go
@@ -122,9 +122,10 @@ func extractTar(tarball []byte, chown bool, dirpath string, filesystem output.Fi
 				return errors.Wrapf(err, "error reading %s", header.Name)
 			}
 
-			// To avoid path-traversal issues a la CVE-2021-43798, prepend a '/' to the front
-			// of the name before checking to see if it canonical, since by default filepath.Clean
-			// does not remove .. at the beginning of a path unless it is rooted.
+			// To avoid path-traversal issues a la https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43798,
+			// prepend a '/' to the front of the name before checking to see if it's canonical, since by default
+			// filepath.Clean (https://pkg.go.dev/path/filepath#Clean) does not remove .. at the beginning of a
+			// path unless it is rooted.
 			//
 			// DO NOT use path.Join or filepath.Join to prepend the '/', since that also Cleans the
 			// resulting path before returning it.

--- a/backup/tar.go
+++ b/backup/tar.go
@@ -8,11 +8,14 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/square/keysync/output"
 
 	"github.com/pkg/errors"
 )
+
+var NonCanonicalPathError = errors.New("non-canonical file path in archive")
 
 // Given a path to a directory, create and return a tarball of its content.
 // Careful, as this will pull the full contents into memory.
@@ -119,8 +122,19 @@ func extractTar(tarball []byte, chown bool, dirpath string, filesystem output.Fi
 				return errors.Wrapf(err, "error reading %s", header.Name)
 			}
 
-			if header.Name != filepath.Clean(header.Name) {
-				return fmt.Errorf("non-canonical file path in archive: %s", header.Name)
+			// To avoid path-traversal issues a la CVE-2021-43798, prepend a '/' to the front
+			// of the name before checking to see if it canonical, since by default filepath.Clean
+			// does not remove .. at the beginning of a path unless it is rooted.
+			//
+			// DO NOT use path.Join or filepath.Join to prepend the '/', since that also Cleans the
+			// resulting path before returning it.
+			name := header.Name
+			separator := string([]rune{os.PathSeparator})
+			if !strings.HasPrefix(name, separator) {
+				name = separator + name
+			}
+			if name != filepath.Clean(name) {
+				return fmt.Errorf("%w: %s", NonCanonicalPathError, header.Name)
 			}
 			path := filepath.Join(dirpath, header.Name)
 


### PR DESCRIPTION
We use `filepath.Clean` to check for non-canonical files in a tarball we're restoring, but `filepath.Clean` does not remove `..` at the beginning of a filename unless it is rooted (i.e. starts with `/`), so files of that form can bypass the check. To fix this, prepend a `/` to the filenames in the tarball before comparing with the cleaned version.

Note that it's important to do this manually and not with `path.Join` or similar, since those APIs `Clean` the resulting path.